### PR TITLE
CAF-2561

### DIFF
--- a/job-service-container/pom.xml
+++ b/job-service-container/pom.xml
@@ -386,21 +386,15 @@
                             <alias>keystore</alias>
                             <name>${project.artifactId}-keystore:${project.version}</name>
                             <build>
+                                <from>java:8</from>
                                 <maintainer>conal.smith@hpe.com</maintainer>
-                                <assembly>
-                                    <basedir>/test-keystore</basedir>
-                                    <inline>
-                                        <fileSets>
-                                            <fileSet>
-                                                <directory>test-keystore</directory>
-                                                <outputDirectory>/</outputDirectory>
-                                                <includes>
-                                                    <include>*</include>
-                                                </includes>
-                                            </fileSet>
-                                        </fileSets>
-                                    </inline>
-                                </assembly>
+                                <runCmds>
+                                    <runCmd>mkdir /test-keystore</runCmd>
+                                    <runCmd>$JAVA_HOME/bin/keytool -genkey -noprompt -alias tomcat -dname "CN=myname, OU=myorganisational.unit, O=myorganisation, L=mycity, S=myprovince, C=GB" -keystore /test-keystore/tomcat.keystore -storepass changeit -keypass changeit -keyalg RSA</runCmd>
+                                </runCmds>
+                                <volumes>
+                                    <volume>/test-keystore</volume>
+                                </volumes>
                             </build>
                         </image>
                         <image>


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-2561

1. Pom builds a java:8 image
2. Creates /test-keystore
3. Runs the keytool to generate keystore
4. Exposes this folder for the job-service to see
5. Job Service, as before, mounts keystore container as a volume

_Note that the runCmd is in the `build` section. Andy had suggested this was no good, that this would build one keystore and use the same each time. The test keystore is for testing only. Every time the build machine runs integration tests, the keystore image will be built, generating a new test keystore. In production, the job-service image won't have this `/test-keystore` directory. This is a mounted volume and does not exist outside of integration tests. Therefore, the keystore IS newly generated for each integration test and this can be done in the `build` section, and this fix is acceptable._