### PR TITLE
CAF-3517: Further copyright updates

### DIFF
--- a/docs/_data/footer_links.json
+++ b/docs/_data/footer_links.json
@@ -1,7 +1,7 @@
 {
   "navigation_items": [],
   "feedback_url": "https://github.com/JobService/job-service/issues",
-  "copyright": "© 2017 Hewlett Packard Enterprise",
+  "copyright": "© 2017 EntIT Software LLC, a Micro Focus company.",
   "footer_logo": "assets/img/job-service-logo.png",
   "footer_columns": [{
     "title": {

--- a/job-service-client/pom.xml
+++ b/job-service-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+    Copyright 2015-2017 EntIT Software LLC, a Micro Focus company.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -33,6 +33,11 @@
         <version>1.9.0-197</version>
         <relativePath/>
     </parent>
+    
+    <organization>
+        <name>EntIT Software LLC, a Micro Focus company</name>
+        <url>https://www.microfocus.com</url>
+    </organization>
 
     <properties>
         <swagger-contract-artifactId>job-service-contract</swagger-contract-artifactId>


### PR DESCRIPTION
Further updates to copyright strings that were missed by maven license plugin, note I also had to add the new organisation to the job-service-client pom as it did not parent off the aggregator project.