### PR TITLE
CAF-3644: Job creation with prerequisiteJobIds

### DIFF
--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -131,6 +131,8 @@ paths:
       responses:
         201:
           description: Indicates that the job was successfully created.
+        202:
+          description: Indicates that the job was accepted but cannot be progressed as one or more prerequisite jobs have not yet completed.
         204:
           description: Indicates that the job was successfully updated.
         400:
@@ -260,6 +262,11 @@ definitions:
           components.
       task:
         $ref: "#/definitions/worker-action"
+      prerequisiteJobIds:
+        type: array
+        items:
+          type: string
+        description: List of job identifiers that must be complete prior to the start of this job.
   worker-action:
     type: object
     required:


### PR DESCRIPTION
Changes to the swagger contract to enable creation of Jobs with prerequisiteJobIds that need completed before job execution.