### PR TITLE
CAF-3552: Use latest caf-common and swagger-restapi-client-base to enable swagger rebrand

### DIFF
--- a/job-service-client/pom.xml
+++ b/job-service-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>swagger-restapi-client-base</artifactId>
-        <version>1.9.0-197</version>
+        <version>1.14.0-1</version>
         <relativePath/>
     </parent>
     

--- a/job-service-ui/pom.xml
+++ b/job-service-ui/pom.xml
@@ -68,7 +68,6 @@
                                 <artifactItem>
                                     <groupId>com.github.cafapi</groupId>
                                     <artifactId>swagger-ui</artifactId>
-									<version>1.0.0</version>
                                     <outputDirectory>${project.build.directory}/swagger-ui</outputDirectory>
                                     <excludes>**/META-INF/**</excludes>
                                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common</artifactId>
-        <version>1.13.0-239</version>
+        <version>1.14.0-1</version>
     </parent>
     
     <organization>


### PR DESCRIPTION
Also removed a version of swagger-ui in job-service-ui project which should be inherited.