### PR TITLE
CAF-3648: Job Service Docs

### DIFF
--- a/docs/pages/en-us/Architecture.md
+++ b/docs/pages/en-us/Architecture.md
@@ -99,7 +99,7 @@ When the job tracking worker receives a success message to be proxied (that is, 
 
 The job tracking worker recognizes failure and retry messages, which are being proxied, and updates the job database accordingly.
 
-The job tracking worker can also automatically forward on dependent jobs for execution.  A dependent job is a job which must wait until a specific job or list of jobs have completed before it, itself can be executed.  As the job tracking worker monitors a job's progress, should a job complete, the job tracking worker will receive a list of jobs which can now be executed as the job(s) which these jobs were dependent upon have now Completed.
+The job tracking worker can also automatically forward on dependent jobs for execution.  A dependent job is a job which must wait until a specific job or list of jobs have completed before it can be executed.  The job tracking worker monitors a job's progress, when a job completes, the job tracking worker will receive a list of jobs which can now be executed as the job(s) which these jobs were dependent upon have now completed.
 
 ## Job Database
 
@@ -129,7 +129,7 @@ When a task is marked complete, the system checks whether the parent task (or th
 
 ### Job Dependency Table
 
-This table stories Ids of dependent jobs.  Jobs which must be completed before the job in question can be executed.
+This table stores Ids of dependent jobs i.e. jobs which must be completed before the job in question can be executed.
 
 | **Column**        | **Data Type** | **Nullable?** | **Primary Key?** |
 |-------------------|---------------|---------------|------------------|
@@ -138,7 +138,7 @@ This table stories Ids of dependent jobs.  Jobs which must be completed before t
 
 ### Job Task Data
 
-This table stores information on jobs which have dependent jobs and must waiting for execution.  The table contains enough information for the job tracking worker to forward on the job once it's dependent jobs have all completed.
+This table stores information on jobs which have dependent jobs and must wait for execution.  The table contains enough information for the job tracking worker to forward on the job, once it's dependent jobs have all completed.
 
 | **Column**        | **Data Type** | **Nullable?** | **Primary Key?** |
 |-------------------|---------------|---------------|------------------|

--- a/docs/pages/en-us/Architecture.md
+++ b/docs/pages/en-us/Architecture.md
@@ -99,7 +99,7 @@ When the job tracking worker receives a success message to be proxied (that is, 
 
 The job tracking worker recognizes failure and retry messages, which are being proxied, and updates the job database accordingly.
 
-The job tracking worker can also automatically forward on dependent jobs for execution.  A dependent job is a job which must wait until a specific job or list of jobs have completed before it can be executed.  The job tracking worker monitors a job's progress, when a job completes, the job tracking worker will receive a list of jobs which can now be executed as the job(s) which these jobs were dependent upon have now completed.
+The job tracking worker can also automatically forward on dependent jobs for execution.  A dependent job is a job which must wait until a specific job or list of jobs have completed before it can be executed.  The job tracking worker monitors a job's progress, when a job completes, the job tracking worker will receive a list of jobs which can now be executed.
 
 ## Job Database
 
@@ -134,7 +134,7 @@ This table stores Ids of dependent jobs i.e. jobs which must be completed before
 | **Column**        | **Data Type** | **Nullable?** | **Primary Key?** |
 |-------------------|---------------|---------------|------------------|
 | Job_Id            | String        | No            | Yes              |
-| Dependent_Job_Id  | String        | No            |                  |
+| Dependent_Job_Id  | String        | No            | Yes              |
 
 ### Job Task Data
 

--- a/docs/pages/en-us/Architecture.md
+++ b/docs/pages/en-us/Architecture.md
@@ -144,8 +144,8 @@ This table stores information on jobs which have dependent jobs and must wait fo
 |-------------------|---------------|---------------|------------------|
 | Job_Id            | String        | No            | Yes              |
 | Task_Classifier   | String        | No            |                  |
-| Task_Api_Version  | String        | No            |                  |
-| Task_Data         | String        | No            |                  |
+| Task_Api_Version  | Integer       | No            |                  |
+| Task_Data         | ByteA         | No            |                  |
 | Task_Pipe         | String        | No            |                  |
 | Target_Pipe       | String        | No            |                  |
 

--- a/docs/pages/en-us/Architecture.md
+++ b/docs/pages/en-us/Architecture.md
@@ -99,7 +99,7 @@ When the job tracking worker receives a success message to be proxied (that is, 
 
 The job tracking worker recognizes failure and retry messages, which are being proxied, and updates the job database accordingly.
 
-The job tracking worker can also automatically forward on dependent jobs for execution.  A dependent job is a job which must wait until a specific job or list of jobs have completed before it, itself can be executed.  As the job tracking worker monitors a job's progress, should a job completed, the job tracking worker will receive a list of jobs which can now be executed as the job(s) which these jobs were dependent upon have now Completed.
+The job tracking worker can also automatically forward on dependent jobs for execution.  A dependent job is a job which must wait until a specific job or list of jobs have completed before it, itself can be executed.  As the job tracking worker monitors a job's progress, should a job complete, the job tracking worker will receive a list of jobs which can now be executed as the job(s) which these jobs were dependent upon have now Completed.
 
 ## Job Database
 

--- a/docs/pages/en-us/Architecture.md
+++ b/docs/pages/en-us/Architecture.md
@@ -34,6 +34,7 @@ The pipes represent asynchronous message queues on RabbitMQ.
 9. The job tracking worker makes a decision:
  - If the `to` field is the same as the `trackTo` field, the task is marked complete in the database and sent to the target pipe without tracking information.
  - Otherwise, the task is sent to the target pipe with tracking information and processed by the worker consuming from the target pipe.
+ - If a job completes and has associated dependent jobs, the job tracking worker receives a list of jobs now available for execution. The job tracking worker forwards these jobs to the target pipe.
 10. A worker consumes messages from the target pipe and processes the task. In this case, the example worker consumes from worker-example-in.
 11. If tracking information is present, tasks are re-routed to the tracking pipe. Otherwise, the task has completed and the response is sent to the output queue, in this case, worker-example-out.
 

--- a/docs/pages/en-us/Features.md
+++ b/docs/pages/en-us/Features.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Features
-last_updated: Last modified by Conal Smith on April 10, 2017
 
 banner:
     icon: 'assets/img/fork-lift.png'
@@ -25,6 +24,10 @@ The Job Service splits large batches of work into smaller batches, until the ind
 ## Elastic Scaling
 
 The process of batch splitting is scaled with the autoscaler. Sub-batches can be processed in parallel. Workers also scale up and down depending on the type of work to be performed on the item, which makes maximum use of the available resources.
+
+## Dependent Jobs
+
+The Job Service can accept a job and a list of dependent jobs.  The Job Service causes the job to wait until all dependent jobs have completed before automatically executing the job.
 
 
 

--- a/docs/pages/en-us/Overview.md
+++ b/docs/pages/en-us/Overview.md
@@ -37,7 +37,7 @@ The batch worker takes batches of work, recursively breaks them down into ever s
 The Job Service is particularly beneficial to the batch worker because it monitors the progress of the batch as a whole. Even if the size of the batch is not known in advance, using the Job Service makes it possible to monitor the overall progress of the entire batch, as well as making other operations available, such as the capability to cancel the batch.
 
 ### Dependent Jobs
-The Job Service has the ability to execute jobs in an order defined by a job having a dependency on another job.  The Job Service will not execute a job until all the jobs it is dependent upon have completed.  Once all dependent jobs have completed the Job Service will automatically execute the job which was previous waiting upon dependent jobs.
+The Job Service has the ability to execute jobs in an order defined by a job having a dependency on another job.  The Job Service will not execute a job until all the jobs it is dependent upon have completed.  Once all dependent jobs have completed the Job Service will automatically execute the job which was previously waiting upon dependent jobs.
 
 #### Example Usages
 The combination of the Job Service and the batch worker is used in a number of document processing scenarios. Here are some examples of this:

--- a/docs/pages/en-us/Overview.md
+++ b/docs/pages/en-us/Overview.md
@@ -39,7 +39,7 @@ The Job Service is particularly beneficial to the batch worker because it monito
 ### Dependent Jobs
 The Job Service has the ability to execute jobs in an order defined by a job having a dependency on another job.  The Job Service will not execute a job until all the jobs it is dependent upon have completed.  Once all dependent jobs have completed the Job Service will automatically execute the job which was previously waiting upon dependent jobs.
 
-#### Example Usages
+### Example Usages
 The combination of the Job Service and the batch worker is used in a number of document processing scenarios. Here are some examples of this:
 
 - Document Reprocessing: A set of documents that have already been ingested is put through the ingestion process again. For example, you might re-ingest because of some updates to the process).

--- a/docs/pages/en-us/Overview.md
+++ b/docs/pages/en-us/Overview.md
@@ -36,6 +36,9 @@ The batch worker takes batches of work, recursively breaks them down into ever s
 
 The Job Service is particularly beneficial to the batch worker because it monitors the progress of the batch as a whole. Even if the size of the batch is not known in advance, using the Job Service makes it possible to monitor the overall progress of the entire batch, as well as making other operations available, such as the capability to cancel the batch.
 
+### Dependent Jobs
+The Job Service has the ability to execute jobs in an order defined by a job having a dependency on another job.  The Job Service will not execute a job until all the jobs it is dependent upon have completed.  Once all dependent jobs have completed the Job Service will automatically execute the job which was previous waiting upon dependent jobs.
+
 #### Example Usages
 The combination of the Job Service and the batch worker is used in a number of document processing scenarios. Here are some examples of this:
 

--- a/worker-jobtracking/README.md
+++ b/worker-jobtracking/README.md
@@ -7,3 +7,5 @@ Messages will typically arrive at the Job Tracking Worker because the queue that
 trackingPipe in a task message, which will trigger the Worker Framework to re-route the message to the Job Tracking Worker. The worker
 checks for task cancellation, reports the progress of the task to the Job Database, and forwards the message to the correct destination
 queue, e.g. the input queue of another worker.
+
+The Job Service has the ability to execute jobs in an order defined by a job having a dependency on another job.  The Job Service will not execute a job until all the jobs it is dependent upon have completed.  As the job tracking worker monitors the progress of jobs, once all dependent jobs have been completed the job tracking worker will automatically forward on the jobs for execution which were previous waiting upon dependent jobs.

--- a/worker-jobtracking/README.md
+++ b/worker-jobtracking/README.md
@@ -8,4 +8,4 @@ trackingPipe in a task message, which will trigger the Worker Framework to re-ro
 checks for task cancellation, reports the progress of the task to the Job Database, and forwards the message to the correct destination
 queue, e.g. the input queue of another worker.
 
-The Job Service has the ability to execute jobs in an order defined by a job having a dependency on another job.  The Job Service will not execute a job until all the jobs it is dependent upon have completed.  As the job tracking worker monitors the progress of jobs, once all dependent jobs have been completed the job tracking worker will automatically forward on the jobs for execution which were previous waiting upon dependent jobs.
+The Job Service has the ability to execute jobs in an order defined by a job having a dependency on another job.  The Job Service will not execute a job until all the jobs it is dependent upon have completed.  The job tracking worker monitors the progress of jobs, once all dependent jobs have been completed the job tracking worker will automatically forward on the jobs for execution which were previously waiting upon dependent jobs.


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-3648

Document changes to the Job Service documentation in relation to supporting "dependent jobs".