### PR TITLE
CAF-3646: Handling blank or empty prereqs passed to job creation

### DIFF
--- a/job-service-acceptance-tests/src/integration-test/java/com/hpe/caf/jobservice/acceptance/JobServiceEndToEndIT.java
+++ b/job-service-acceptance-tests/src/integration-test/java/com/hpe/caf/jobservice/acceptance/JobServiceEndToEndIT.java
@@ -222,8 +222,9 @@ public class JobServiceEndToEndIT {
         Thread.sleep(10000); // Sleep for a second to allow previous jobs to complete
 
         final String job3Id = generateJobId();
-        // Add job that has prerequisite job 1 (completed) and job 2 (completed)
-        createJobWithPrerequisites(job3Id, true, job1Id, job2Id);
+        // Add job that has prerequisite job 1 (completed) and job 2 (completed). Also supply blank, null and empty
+        // prereq job ids that should not hold the job back.
+        createJobWithPrerequisites(job3Id, true, job1Id, job2Id, "", null, "           ");
 
         try (final Connection dbConnection = getDbConnection()) {
 
@@ -246,6 +247,43 @@ public class JobServiceEndToEndIT {
             Assert.assertFalse(rs.next());
             rs.close();
             st.close();
+        }
+    }
+
+    @Test
+    public void testJobWithNullAndBlankAndEmptyPrereqJobsShouldComplete() throws Exception
+    {
+        numTestItemsToGenerate = 1;                 // CAF-3677: Remove this on fix
+        testItemAssetIds = generateWorkerBatch();   // CAF-3677: Remove this on fix
+        final String job1Id = generateJobId();
+
+        JobServiceEndToEndITExpectation job1Expectation =
+                new JobServiceEndToEndITExpectation(
+                        false,
+                        exampleWorkerMessageOutQueue,
+                        job1Id,
+                        jobCorrelationId,
+                        ExampleWorkerConstants.WORKER_NAME,
+                        ExampleWorkerConstants.WORKER_API_VER,
+                        TaskStatus.RESULT_SUCCESS,
+                        ExampleWorkerStatus.COMPLETED,
+                        testItemAssetIds);
+
+        // Add a Prerequisite job 1 that should be completed
+        try (QueueManager queueManager = getFinalQueueManager()) {
+            ExecutionContext context = new ExecutionContext(false);
+            context.initializeContext();
+            getTimer(context);
+            queueManager.start(new FinalOutputDeliveryHandler(workerServices.getCodec(), jobsApi, context,
+                    job1Expectation));
+
+            // Add job that has prerequisite jobs that are empty, null and blank
+            createJobWithPrerequisites(job1Id, true, "", null, "           ");
+
+            // Waits for the final result message to appear on the Example worker's output queue.
+            // When we read it from this queue it should have been processed fully and its status reported to the Job Database as Completed.
+            TestResult result = context.getTestResult();
+            Assert.assertTrue(result.isSuccess());
         }
     }
 

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
@@ -34,8 +34,8 @@ import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public final class JobsPut {
 
@@ -143,6 +143,12 @@ public final class JobsPut {
             if (!rowExists){
                 targetOperation = "create";
 
+                // Remove all null or blank prerequisite job ids from the job's list of prerequisiteJobIds
+                if (job.getPrerequisiteJobIds() != null && !job.getPrerequisiteJobIds().isEmpty()) {
+                    job.setPrerequisiteJobIds(job.getPrerequisiteJobIds().stream()
+                            .filter(prereqJobId -> prereqJobId != null && !prereqJobId.trim().isEmpty())
+                            .collect(Collectors.toList()));
+                }
 
                 //  Create job in the database.
                 LOG.info("createOrUpdateJob: Creating job in the database...");


### PR DESCRIPTION
Now removing all null or blank prerequisite job ids from the job's list of prerequisiteJobIds passed to the service. Added test for the case.