### PR TITLE
CAF-3696: HTTP 202 replaced with 201 for jobs waiting on prerequisites

### DIFF
--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -131,8 +131,6 @@ paths:
       responses:
         201:
           description: Indicates that the job was successfully created.
-        202:
-          description: Indicates that the job was accepted but cannot be progressed as one or more prerequisite jobs have not yet completed.
         204:
           description: Indicates that the job was successfully updated.
         400:

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
@@ -163,6 +163,12 @@ public final class JobsPut {
                     databaseHelper.createJob(jobId, job.getName(), job.getDescription(), job.getExternalData(), jobHash);
                 }
 
+                // Check if job_task_data row exists for the specified job_id and if it does return 'accepted'
+                // and not 'created'.
+                if (!databaseHelper.canJobBeProgressed(jobId)) {
+                    return targetOperation;
+                }
+
                 //  Get database helper instance.
                 try {
                     QueueServices queueServices = QueueServicesFactory.create(config, job.getTask().getTaskPipe(),codec);

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
@@ -163,12 +163,6 @@ public final class JobsPut {
                     databaseHelper.createJob(jobId, job.getName(), job.getDescription(), job.getExternalData(), jobHash);
                 }
 
-                // Check if job_task_data row exists for the specified job_id and if it does return 'accepted'
-                // and not 'created'.
-                if (!databaseHelper.canJobBeProgressed(jobId)) {
-                    return "accept";
-                }
-
                 //  Get database helper instance.
                 try {
                     QueueServices queueServices = QueueServicesFactory.create(config, job.getTask().getTaskPipe(),codec);

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
@@ -79,8 +79,6 @@ public class JobsApi  {
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 201, message = "Indicates that the job was successfully created", response = void.class),
 
-            @io.swagger.annotations.ApiResponse(code = 202, message = "Indicates that the job was accepted but cannot be progressed as one or more prerequisite jobs have not yet completed.", response = void.class),
-
             @io.swagger.annotations.ApiResponse(code = 204, message = "Indicates that the job was successfully updated", response = void.class),
 
             @io.swagger.annotations.ApiResponse(code = 400, message = "The `jobId` parameter contains invalid characters.", response = void.class) })

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiServiceImpl.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiServiceImpl.java
@@ -67,9 +67,6 @@ public class JobsApiServiceImpl extends JobsApiService {
             if (createOrUpdate.equals("create")) {
                 //  Return HTTP 201 for successful create.
                 return Response.created(uriInfo.getRequestUri()).build();
-            } else if (createOrUpdate.equals("accept")) {
-                //  Return HTTP 202 for accepted.
-                return Response.status(Response.Status.ACCEPTED).location(uriInfo.getRequestUri()).build();
             } else {
                 //  Must be update - return HTTP 204 for successful update.
                 return Response.noContent().build();

--- a/job-service/src/test/java/com/hpe/caf/services/job/api/JobsPutTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/api/JobsPutTest.java
@@ -117,6 +117,7 @@ public final class JobsPutTest {
     public void testCreateJob_Success_NoMatchingJobRow() throws Exception {
 
         when(mockDatabaseHelper.doesJobAlreadyExist(anyString(), anyInt())).thenReturn(false);
+        when(mockDatabaseHelper.canJobBeProgressed(anyString())).thenReturn(true);
 
         //  Test successful run of job creation when no matching job row exists.
         JobsPut.createOrUpdateJob("067e6162-3b6f-4ae2-a171-2470b63dff00", validJob);
@@ -189,6 +190,7 @@ public final class JobsPutTest {
     public void testJobCreationWithTaskData_Object() throws Exception
     {
         when(mockDatabaseHelper.doesJobAlreadyExist(anyString(), anyInt())).thenReturn(false);
+        when(mockDatabaseHelper.canJobBeProgressed(anyString())).thenReturn(true);
         
         NewJob job = new NewJob();
         WorkerAction action = new WorkerAction();
@@ -214,6 +216,7 @@ public final class JobsPutTest {
     public void testJobCreationWithPrerequisites() throws Exception
     {
         when(mockDatabaseHelper.doesJobAlreadyExist(anyString(), anyInt())).thenReturn(false);
+        when(mockDatabaseHelper.canJobBeProgressed(anyString())).thenReturn(false);
 
         NewJob job = new NewJob();
         WorkerAction action = new WorkerAction();
@@ -237,6 +240,7 @@ public final class JobsPutTest {
         verify(mockDatabaseHelper, times(1)).doesJobAlreadyExist(anyString(), anyInt());
         verify(mockDatabaseHelper, times(1)).createJobWithDependencies(anyString(),anyString(),anyString(),anyString(),anyInt(),
                 anyString(),anyInt(), any(), anyString(), anyString(), any());
+        verify(mockDatabaseHelper, times(1)).canJobBeProgressed(anyString());
     }
     
     

--- a/job-service/src/test/java/com/hpe/caf/services/job/api/JobsPutTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/api/JobsPutTest.java
@@ -117,7 +117,6 @@ public final class JobsPutTest {
     public void testCreateJob_Success_NoMatchingJobRow() throws Exception {
 
         when(mockDatabaseHelper.doesJobAlreadyExist(anyString(), anyInt())).thenReturn(false);
-        when(mockDatabaseHelper.canJobBeProgressed(anyString())).thenReturn(true);
 
         //  Test successful run of job creation when no matching job row exists.
         JobsPut.createOrUpdateJob("067e6162-3b6f-4ae2-a171-2470b63dff00", validJob);
@@ -190,7 +189,6 @@ public final class JobsPutTest {
     public void testJobCreationWithTaskData_Object() throws Exception
     {
         when(mockDatabaseHelper.doesJobAlreadyExist(anyString(), anyInt())).thenReturn(false);
-        when(mockDatabaseHelper.canJobBeProgressed(anyString())).thenReturn(true);
         
         NewJob job = new NewJob();
         WorkerAction action = new WorkerAction();
@@ -216,7 +214,6 @@ public final class JobsPutTest {
     public void testJobCreationWithPrerequisites() throws Exception
     {
         when(mockDatabaseHelper.doesJobAlreadyExist(anyString(), anyInt())).thenReturn(false);
-        when(mockDatabaseHelper.canJobBeProgressed(anyString())).thenReturn(false);
 
         NewJob job = new NewJob();
         WorkerAction action = new WorkerAction();
@@ -231,16 +228,15 @@ public final class JobsPutTest {
         job.setTask(action);
         job.setPrerequisiteJobIds(Arrays.asList(new String[]{"J1", "J2"}));
 
-        //  Test acceptance of job when no matching job row exists and job has prereqs that have not been completed.
+        //  Test creation of job when no matching job row exists and job has prereqs that have not been completed.
         final String createOrUpdateJobReturnString = JobsPut.createOrUpdateJob("067e6162-3b6f-4ae2-a171-2470b63dff00",
                 job);
 
-        assertEquals("accept", createOrUpdateJobReturnString);
+        assertEquals("create", createOrUpdateJobReturnString);
 
         verify(mockDatabaseHelper, times(1)).doesJobAlreadyExist(anyString(), anyInt());
         verify(mockDatabaseHelper, times(1)).createJobWithDependencies(anyString(),anyString(),anyString(),anyString(),anyInt(),
                 anyString(),anyInt(), any(), anyString(), anyString(), any());
-        verify(mockDatabaseHelper, times(1)).canJobBeProgressed(anyString());
     }
     
     


### PR DESCRIPTION
The Job Service now returns a 201 for jobs waiting because of prerequisites. Developer build passing - see http://sou-jenkins2.hpeswlab.net/job/JobService/view/Developer/job/JobService~job-service~CAF-3696_Remove_202_Reponse~CI/3/