### PR TITLE
CAF-3894: Use postgres 'quoted identifiers' during index creation for dynamic task tables

### DIFF
--- a/job-service-db/src/main/resources/procedures/createTaskTable.sql
+++ b/job-service-db/src/main/resources/procedures/createTaskTable.sql
@@ -45,12 +45,12 @@ BEGIN
   )', in_table_name, 'pk_' || in_table_name);
 
   -- Create indexes.
-  v_index_name = 'idx_' || in_table_name || '_s';
+  v_index_name = '"idx_' || in_table_name || '_s"';
   IF (SELECT internal_to_regclass(v_index_name)) IS NULL THEN
     EXECUTE format('CREATE INDEX %1$I ON %2$I (%3$I)',v_index_name, in_table_name, 'status');
   END IF;
 
-  v_index_name = 'idx_' || in_table_name || '_if';
+  v_index_name = '"idx_' || in_table_name || '_if"';
   IF (SELECT internal_to_regclass(v_index_name)) IS NULL THEN
     EXECUTE format('CREATE INDEX %1$I ON %2$I (%3$I)',v_index_name, in_table_name, 'is_final');
   END IF;

--- a/job-service-db/src/main/resources/v2.3.1/changelog.xml
+++ b/job-service-db/src/main/resources/v2.3.1/changelog.xml
@@ -19,14 +19,13 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-                                       http://www.liquibase.org/xml/ns/dbchangelog 
-                                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-   <include file="changelog.xml" relativeToChangelogFile="true"/>
-   <include file="v1.3.0/changelog.xml" relativeToChangelogFile="true" />
-   <include file="v1.9.0/changelog.xml" relativeToChangelogFile="true" />
-   <include file="v2.1.0/changelog.xml" relativeToChangelogFile="true" />
-   <include file="v2.3.0/changelog.xml" relativeToChangelogFile="true" />
-   <include file="v2.3.1/changelog.xml" relativeToChangelogFile="true" />
+    <changeSet id="update_procedure_internal_create_task_table_index_creation_change" runOnChange="true" author="Connor Mulholland" >
+        <createProcedure path="procedures/createTaskTable.sql"
+                         procedureName="internal_create_task_table"
+                         schemaName="public">
+        </createProcedure>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Proposed changes to avoid 'cross-database references are not implemented' errors when creating the dynamic task tables. https://jira.autonomy.com/browse/CAF-3894

Developer build passing - http://sou-jenkins2.hpeswlab.net/job/JobService/view/Developer/job/JobService~job-service~CAF-3894_Fix_Index_Creation_Issue~CI/