### PR TITLE
CAF-3904: Job Tracking Worker concurrency issues

### DIFF
--- a/job-service-db/src/main/resources/procedures/createTaskTable.sql
+++ b/job-service-db/src/main/resources/procedures/createTaskTable.sql
@@ -45,15 +45,8 @@ BEGIN
   )', in_table_name, 'pk_' || in_table_name);
 
   -- Create indexes.
-  v_index_name = 'idx_' || in_table_name || '_s';
-  IF (SELECT internal_to_regclass(v_index_name)) IS NULL THEN
-    EXECUTE format('CREATE INDEX %1$I ON %2$I (%3$I)',v_index_name, in_table_name, 'status');
-  END IF;
-
-  v_index_name = 'idx_' || in_table_name || '_if';
-  IF (SELECT internal_to_regclass(v_index_name)) IS NULL THEN
-    EXECUTE format('CREATE INDEX %1$I ON %2$I (%3$I)',v_index_name, in_table_name, 'is_final');
-  END IF;
+  EXECUTE format('CREATE INDEX ON %1$I (%2$I)', in_table_name, 'status');
+  EXECUTE format('CREATE INDEX ON %1$I (%2$I)', in_table_name, 'is_final');
 
 END
 $$ LANGUAGE plpgsql;

--- a/job-service-db/src/main/resources/procedures/createTaskTable.sql
+++ b/job-service-db/src/main/resources/procedures/createTaskTable.sql
@@ -23,7 +23,8 @@
 CREATE OR REPLACE FUNCTION internal_create_task_table(in_table_name varchar(63))
 RETURNS VOID AS $$
 DECLARE
-  v_index_name VARCHAR(63);
+  v_status_index_name VARCHAR(63);
+  v_is_final_index_name VARCHAR(63);
 BEGIN
 
   --  Raise exception if task table name has not been specified.
@@ -45,8 +46,11 @@ BEGIN
   )', in_table_name, 'pk_' || in_table_name);
 
   -- Create indexes.
-  EXECUTE format('CREATE INDEX ON %1$I (%2$I)', in_table_name, 'status');
-  EXECUTE format('CREATE INDEX ON %1$I (%2$I)', in_table_name, 'is_final');
+  SELECT 'idx_' || MD5(random()::text) || '_status' INTO v_status_index_name;
+  EXECUTE format('CREATE INDEX %1$I ON %2$I (%3$I)',v_status_index_name, in_table_name, 'status');
+
+  SELECT 'idx_' || MD5(random()::text) || '_is_final' INTO v_is_final_index_name;
+  EXECUTE format('CREATE INDEX %1$I ON %2$I (%3$I)',v_is_final_index_name, in_table_name, 'is_final');
 
 END
 $$ LANGUAGE plpgsql;

--- a/job-service-db/src/main/resources/procedures/deleteTaskTable.sql
+++ b/job-service-db/src/main/resources/procedures/deleteTaskTable.sql
@@ -34,7 +34,7 @@ BEGIN
   END IF;
 
   --  Identify task tables associated with the specified job.
-  EXECUTE 'SELECT ARRAY(SELECT relname FROM pg_class WHERE relname LIKE $1)' INTO v_tables_to_delete  USING 'task_' || in_job_id || '%';
+  EXECUTE 'SELECT ARRAY(SELECT relname FROM pg_class WHERE relname LIKE $1 AND relkind = ''r'')' INTO v_tables_to_delete  USING 'task_' || in_job_id || '%';
 
   --  Loop through each task table.
   FOREACH v_table_name IN ARRAY v_tables_to_delete

--- a/job-service-db/src/main/resources/v2.3.1/changelog.xml
+++ b/job-service-db/src/main/resources/v2.3.1/changelog.xml
@@ -21,11 +21,24 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <changeSet id="update_procedure_internal_report_task_completion_clean_up_tables_change" runOnChange="true" author="Connor Mulholland" >
-        <createProcedure path="procedures/reportTaskCompletion.sql"
-                         procedureName="internal_report_task_completion"
+    <changeSet id="update_procedure_internal_create_task_table_index_name_change" runOnChange="true" author="Connor Mulholland" >
+        <createProcedure path="procedures/createTaskTable.sql"
+                         procedureName="internal_create_task_table"
                          schemaName="public">
         </createProcedure>
     </changeSet>
 
+    <changeSet id="update_procedure_internal_delete_task_table_index_name_change" runOnChange="true" author="Connor Mulholland" >
+        <createProcedure path="procedures/deleteTaskTable.sql"
+                         procedureName="internal_delete_task_table"
+                         schemaName="public">
+        </createProcedure>
+    </changeSet>
+
+    <changeSet id="update_procedure_report_progress_lock_table_change" runOnChange="true" author="Connor Mulholland" >
+        <createProcedure path="procedures/reportProgress.sql"
+                         procedureName="report_progress"
+                         schemaName="public">
+        </createProcedure>
+    </changeSet>
 </databaseChangeLog>

--- a/release-notes-2.4.0.md
+++ b/release-notes-2.4.0.md
@@ -4,10 +4,12 @@
 ${version-number}
 
 #### New Features
- - [CAF-3893](https://jira.autonomy.com/browse/CAF-3893): Job Tracking Worker logging  
-    Job Tracking Worker logging is now controllable via the CAF_LOG_LEVEL environment variable.
  - [CAF-3881](https://jira.autonomy.com/browse/CAF-3881): Clean tables up as we go  
     The Job Service has been changed to clean up the dynamic task tables in the database when all sub tasks belonging to that task are completed. Before, the tables were
     cleaned up when the entire job was completed.
+ - [CAF-3893](https://jira.autonomy.com/browse/CAF-3893): Job Tracking Worker logging  
+    Job Tracking Worker logging is now controllable via the CAF_LOG_LEVEL environment variable.
+ - [CAF-3904](https://jira.autonomy.com/browse/CAF-3904): Errors reporting progress
+    The Job Tracking Worker has been changed to support a catch and retry mechanism in the event of a database concurrency related exception being detected.
 
 #### Known Issues

--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerReporter.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerReporter.java
@@ -91,7 +91,7 @@ public class JobTrackingWorkerReporter implements JobTrackingReporter {
     public void reportJobTaskProgress(final String jobTaskId, final int estimatedPercentageCompleted) throws JobReportingException {
 
         int retryCount = 0;
-        final int maxRetries = 5;
+        final int maxRetries = 1;
 
         while(true) {
             try (Connection conn = getConnection()) {

--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerReporter.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerReporter.java
@@ -109,7 +109,6 @@ public class JobTrackingWorkerReporter implements JobTrackingReporter {
                     LOG.info(MessageFormat.format("Retrying reportJobTaskProgress() call for job task {0}. Retry count {1}.",
                             jobTaskId, retryCount));
                 } else {
-                    LOG.error(MessageFormat.format(errorMessage, jobTaskId, se.getMessage()));
                     throw new JobReportingException(
                             MessageFormat.format(errorMessage, jobTaskId,
                                     se.getMessage()), se);


### PR DESCRIPTION
Proposed changes to address concurrency related exceptions reported in the JIRA ticket (see https://jira.autonomy.com/browse/CAF-3904). In summary:
1. The Job Tracking Worker has been changed to support catch/retry when concurrency related exceptions are detected. These can arise if multiple transactions attempt to create tables and indexes at the same time.
2. The ReportProgress DB function has been modified to take an exclusive table lock on the top most dynamic task table to prevent concurrent updates. This fix was needed to protect a different scenario I spotted during additional testing where the a job had been left in Active state even though ALL sub-tasks where completed.
3. Additional DB code was changed to allow postgres to chose a name for indexes created for the dynamic task tables.