### PR TITLE
SCMOD-4348: Corrected syntax

### DIFF
--- a/job-service-db/src/main/resources/procedures/reportFailure.sql
+++ b/job-service-db/src/main/resources/procedures/reportFailure.sql
@@ -72,7 +72,7 @@ BEGIN
     EXECUTE format('
       WITH upsert AS
       (
-        UPDATE %1$I SET status = ''Failed'', failure_details = concat(failure_details, %L || chr(10)) WHERE task_id = %L; RETURNING *
+        UPDATE %1$I SET status = ''Failed'', failure_details = concat(failure_details, %L || chr(10)) WHERE task_id = %L RETURNING *
       )
       INSERT INTO %1$I (task_id, create_date, status, percentage_complete, failure_details, is_final)
         SELECT %3$L, now() AT TIME ZONE ''UTC'', ''Failed'', 0.00, %2$L, %4$L


### PR DESCRIPTION
Verified that the query ran successfully on larry. See updated row on larry-pdb01 -

 SELECT * FROM public."task_michaelb01_L3QjcNBqRWOmf7RUf50sbQ.1" where task_id = 'michaelb01_L3QjcNBqRWOmf7RUf50sbQ.1.228'