### PR TITLE
Build Failure: Fix for Tini dependency missing

### DIFF
--- a/job-service-acceptance-tests/pom.xml
+++ b/job-service-acceptance-tests/pom.xml
@@ -45,12 +45,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.krallin</groupId>
-            <artifactId>tini</artifactId>
-            <scope>runtime</scope>
-            <type>exe</type>
-        </dependency>
-        <dependency>
             <groupId>com.github.cafapi.config</groupId>
             <artifactId>config-file</artifactId>
         </dependency>


### PR DESCRIPTION
Removed unnecessary dependency that caused the master field to fail.

## Build

http://sou-jenkins2.hpeswlab.net/job/JobService/job/JobService%7Ejob-service%7ETINI%7ECI/