### PR TITLE
SCMOD-6334: document the job ID requirements

### DIFF
--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -95,7 +95,9 @@ paths:
           across different services.
       - name: jobId
         in: path
+        type: string
         required: true
+        description: The identifier of the job
         schema:
           $ref: '#/definitions/jobId'
     get:
@@ -188,7 +190,9 @@ paths:
           across different CAF services
       - name: jobId
         in: path
+        type: string
         required: true
+        description: The identifier of the job
         schema:
           $ref: '#/definitions/jobId'
     post:
@@ -242,8 +246,8 @@ paths:
 definitions:
   jobId:
     type: string
-    format: '^[^.,:;*?!|()]{1,48}$'
     description: The job identifier
+    pattern: '^[^.,:;*?!|()]{1,48}$'
   newJob:
     type: object
     properties:
@@ -303,7 +307,8 @@ definitions:
     type: object
     properties:
       id:
-        $ref: '#/definitions/jobId'
+        type: string
+        description: The job identifier
       name:
         type: string
         description: The name of the job

--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -95,9 +95,9 @@ paths:
           across different services.
       - name: jobId
         in: path
-        type: string
         required: true
-        description: The identifier of the job
+        schema:
+          $ref: '#/definitions/jobId'
     get:
       tags:
         - Jobs
@@ -188,9 +188,9 @@ paths:
           across different CAF services
       - name: jobId
         in: path
-        type: string
         required: true
-        description: The identifier of the job
+        schema:
+          $ref: '#/definitions/jobId'
     post:
       tags:
         - Jobs
@@ -240,6 +240,10 @@ paths:
             type: integer
             format: int64
 definitions:
+  jobId:
+    type: string
+    format: '^[^.,:;*?!|()]{1,48}$'
+    description: The job identifier
   newJob:
     type: object
     properties:
@@ -299,8 +303,7 @@ definitions:
     type: object
     properties:
       id:
-        type: string
-        description: The job identifier
+        $ref: '#/definitions/jobId'
       name:
         type: string
         description: The name of the job

--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -36,6 +36,16 @@ consumes:
   - application/json
 produces:
   - application/json
+
+parameters:
+  jobId:
+    name: jobId
+    in: path
+    type: string
+    required: true
+    description: The identifier of the job
+    pattern: '^[^.,:;*?!|()]{1,48}$'
+
 paths:
   /jobs:
     parameters:
@@ -93,13 +103,7 @@ paths:
         description: |
           An identifier that correlates events 
           across different services.
-      - name: jobId
-        in: path
-        type: string
-        required: true
-        description: The identifier of the job
-        schema:
-          $ref: '#/definitions/jobId'
+      - $ref: '#/parameters/jobId'
     get:
       tags:
         - Jobs
@@ -158,11 +162,7 @@ paths:
         description: |
           An identifier that correlates events 
           across different services.
-      - name: jobId
-        in: path
-        type: string
-        required: true
-        description: The identifier of the job
+      - $ref: '#/parameters/jobId'
     get:
       tags:
         - Jobs
@@ -188,13 +188,7 @@ paths:
         description: |
           An identifier that correlates events 
           across different CAF services
-      - name: jobId
-        in: path
-        type: string
-        required: true
-        description: The identifier of the job
-        schema:
-          $ref: '#/definitions/jobId'
+      - $ref: '#/parameters/jobId'
     post:
       tags:
         - Jobs
@@ -244,10 +238,6 @@ paths:
             type: integer
             format: int64
 definitions:
-  jobId:
-    type: string
-    description: The job identifier
-    pattern: '^[^.,:;*?!|()]{1,48}$'
   newJob:
     type: object
     properties:


### PR DESCRIPTION
This is already validated internally, but it's hard to know how to generate valid job IDs when it's not documented.