### PR TITLE
SCMOD-6216: fixed bug introduced with RETURNING

### DIFF
--- a/job-service-db/src/main/resources/procedures/processDependentJobs.sql
+++ b/job-service-db/src/main/resources/procedures/processDependentJobs.sql
@@ -64,7 +64,8 @@ BEGIN
                             WHERE job_dependency.job_id = job_task_data.job_id);
     
     -- Return jobs with no delay that we can now run and delete the tasks
-    DELETE 
+    RETURN QUERY
+    WITH del_result AS (DELETE 
         FROM job_task_data jtd
         WHERE jtd.job_id IN (
             SELECT jtd.job_id
@@ -76,7 +77,9 @@ BEGIN
                         WHERE job_dependency.job_id = dp.job_id
                 )
         )
-        RETURNING jtd.job_id, jtd.task_classifier, jtd.task_api_version, jtd.task_data, jtd.task_pipe, jtd.target_pipe;
+        RETURNING jtd.job_id, jtd.task_classifier, jtd.task_api_version, jtd.task_data, jtd.task_pipe, jtd.target_pipe)
+    SELECT del_result.job_id, del_result.task_classifier, del_result.task_api_version, del_result.task_data, del_result.task_pipe, del_result.target_pipe
+    FROM del_result;
 
 END
 $$;


### PR DESCRIPTION
## Jira

https://portal.digitalsafe.net/browse/SCMOD-6216

## Notes

Error message,
`{"status":"PROGRESS_UPDATE_FAILED","message":"Failed to report the completion of job task TAG_rajan99_2279_443322.1.1. ERROR: query has no destination for result data\n  Where: PL/pgSQL function internal_process_dependent_jobs(character varying) line 34 at SQL statement\nPL/pgSQL function report_complete(character varying) line 33 at RETURN QUERY"}`

## Build

http://sou-jenkins2.hpeswlab.net/job/JobService/job/JobService%7Ejob-service%7ESCMOD-6216-bug%7ECI/