### PR TITLE
SCMOD-6620: Fix locking in internal_process_dependent_jobs

### DIFF
--- a/job-service-db/src/main/resources/procedures/processDependentJobs.sql
+++ b/job-service-db/src/main/resources/procedures/processDependentJobs.sql
@@ -47,18 +47,19 @@ BEGIN
         WHERE jd.partition_id = in_partition_id
             AND jd.dependent_job_id = in_job_id;
 
-    -- Remove corresponding dependency related rows for jobs that can be processed immediately
-    DELETE
-    FROM job_dependency AS jd
-    WHERE jd.partition_id = in_partition_id
-        AND jd.dependent_job_id = in_job_id;
-
     -- Ensure that no other `job_dependency` deletion can run until we've committed, so we don't
     -- miss the deletion of the last dependency
     PERFORM NULL FROM job_dependency AS jd
     WHERE jd.partition_id = in_partition_id
         AND jd.job_id IN (SELECT tmp_dependent_jobs.job_id FROM tmp_dependent_jobs)
+    ORDER BY jd.partition_id, jd.job_id, jd.dependent_job_id
     FOR KEY SHARE;
+
+    -- Remove corresponding dependency related rows for jobs that can be processed immediately
+    DELETE
+    FROM job_dependency AS jd
+    WHERE jd.partition_id = in_partition_id
+        AND jd.dependent_job_id = in_job_id;
 
     --Set the eligible_to_run_date for jobs with a delay, these will be picked up by scheduled executor
     UPDATE job_task_data

--- a/job-service-db/src/main/resources/v3.0.0/changelog.xml
+++ b/job-service-db/src/main/resources/v3.0.0/changelog.xml
@@ -188,4 +188,11 @@
         </createProcedure>
     </changeSet>
 
+    <changeSet id="update_procedure_internal_process_dependent_jobs_locking_rows" runOnChange="true" author="Gamma Team">
+        <createProcedure path="procedures/processDependentJobs.sql"
+                         procedureName="internal_process_dependent_jobs"
+                         schemaName="public">
+        </createProcedure>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Related to #89.  I've verified that some sort of additional locking is required, and that this is sufficient to avoid the one case that Andy was trying to resolve, by just running transactions manually.  It's different enough from the previous version of the lock that I would expect the deadlock mentioned in #89 not to be possible (though it's not obvious to me where exactly that deadlock was).

----

- build: http://sou-jenkins2.hpeswlab.net/job/JobService/job/JobService~job-service~SCMOD-6620~CI/