### PR TITLE
SCMOD-6622: fix for creating a job with 2 incomplete dependencies

### DIFF
--- a/job-service-acceptance-tests/src/integration-test/java/com/hpe/caf/jobservice/acceptance/JobServiceEndToEndIT.java
+++ b/job-service-acceptance-tests/src/integration-test/java/com/hpe/caf/jobservice/acceptance/JobServiceEndToEndIT.java
@@ -446,6 +446,21 @@ public class JobServiceEndToEndIT {
         JobServiceDatabaseUtil.assertJobDependencyRowsExist(job3Id, job2Id, batchWorkerMessageInQueue, exampleWorkerMessageOutQueue);
     }
 
+    // testing creation of 2 job-dependency rows for the same parent job
+    @Test
+    public void testJobWithPrerequisiteJobsNotCompleted() throws Exception
+    {
+        numTestItemsToGenerate = 2;                 // CAF-3677: Remove this on fix
+        testItemAssetIds = generateWorkerBatch();   // CAF-3677: Remove this on fix
+
+        final String parentJobId = generateJobId();
+        final String child1JobId = generateJobId();
+        final String child2JobId = generateJobId();
+        createJobWithPrerequisites(parentJobId, true, 0, child1JobId, child2JobId);
+
+        JobServiceDatabaseUtil.assertJobStatus(parentJobId, "waiting");
+    }
+
     @Test
     public void testJobWithPrerequisiteJobs() throws Exception
     {

--- a/job-service-db/src/main/resources/procedures/getJob.sql
+++ b/job-service-db/src/main/resources/procedures/getJob.sql
@@ -35,8 +35,7 @@ RETURNS TABLE(
     status job_status,
     percentage_complete DOUBLE PRECISION,
     failure_details TEXT,
-    actionType CHAR(6),
-    can_be_progressed BOOLEAN
+    actionType CHAR(6)
 )
 LANGUAGE plpgsql STABLE
 AS $$
@@ -58,12 +57,8 @@ BEGIN
            job.status,
            job.percentage_complete,
            job.failure_details,
-           CAST('WORKER' AS CHAR(6)) AS actionType,
-           jtd.job_id IS NULL AS can_be_progressed
+           CAST('WORKER' AS CHAR(6)) AS actionType
     FROM job
-    LEFT JOIN job_task_data AS jtd
-        ON jtd.partition_id = job.partition_id
-        AND jtd.job_id = job.job_id
     WHERE job.partition_id = in_partition_id
         AND job.job_id = in_job_id;
 

--- a/job-service-db/src/main/resources/v3.0.0/changelog.xml
+++ b/job-service-db/src/main/resources/v3.0.0/changelog.xml
@@ -63,7 +63,7 @@
         <addPrimaryKey schemaName="public"
                        tableName="job_dependency"
                        constraintName="pk_job_dependency"
-                       columnNames="partition_id, job_id" />
+                       columnNames="partition_id, job_id, dependent_job_id" />
         <addForeignKeyConstraint baseTableSchemaName="public"
                                  baseTableName="job_dependency"
                                  constraintName="fk_job_dependency"


### PR DESCRIPTION
I missed one of the columns when updating the primary key for `job_dependency`.

I've also done some cleanup I missed when we changed the design previously.

----

- ticket: https://portal.digitalsafe.net/browse/SCMOD-6622
- build: http://sou-jenkins2.hpeswlab.net/job/JobService/job/JobService~job-service~SCMOD-6622b~CI/