### PR TITLE
SCMOD-6619: Fix error code on attempted job update

### DIFF
--- a/job-service-container/src/integration-test/java/com/hpe/caf/services/job/api/JobServiceIT.java
+++ b/job-service-container/src/integration-test/java/com/hpe/caf/services/job/api/JobServiceIT.java
@@ -243,8 +243,7 @@ public class JobServiceIT {
         newJob2.setName(newJob2.getName() + " updated");
 
         jobsApi.createOrUpdateJob(defaultPartitionId, jobId, newJob1, correlationId);
-        // TODO: should be FORBIDDEN (SCMOD-6619)
-        assertThrowsApiException(Response.Status.INTERNAL_SERVER_ERROR,
+        assertThrowsApiException(Response.Status.FORBIDDEN,
             () -> jobsApi.createOrUpdateJob(defaultPartitionId, jobId, newJob2, correlationId));
 
         final Job retrievedJob = jobsApi.getJob(defaultPartitionId, jobId, correlationId);
@@ -260,8 +259,7 @@ public class JobServiceIT {
         newJob2.getTask().setTaskApiVersion(newJob2.getTask().getTaskApiVersion() + 7);
 
         jobsApi.createOrUpdateJob(defaultPartitionId, jobId, newJob1, correlationId);
-        // TODO: should be FORBIDDEN (SCMOD-6619)
-        assertThrowsApiException(Response.Status.INTERNAL_SERVER_ERROR,
+        assertThrowsApiException(Response.Status.FORBIDDEN,
             () -> jobsApi.createOrUpdateJob(defaultPartitionId, jobId, newJob2, correlationId));
     }
 

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/ApiExceptionMapper.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/ApiExceptionMapper.java
@@ -15,7 +15,9 @@
  */
 package com.hpe.caf.services.job.api;
 
+import com.hpe.caf.services.job.api.generated.ApiResponseMessage;
 import com.hpe.caf.services.job.exceptions.BadRequestException;
+import com.hpe.caf.services.job.exceptions.ForbiddenException;
 import com.hpe.caf.services.job.exceptions.NotFoundException;
 
 import javax.ws.rs.core.Response;
@@ -37,19 +39,20 @@ public final class ApiExceptionMapper implements ExceptionMapper<Exception> {
      */
     @Override
     public Response toResponse(Exception exception) {
-        //  Default response to HTTP 500 (i.e. INTERNAL SERVER ERROR)
-        Response.Status httpStatus = Response.Status.INTERNAL_SERVER_ERROR;
-
-        //  Map BadRequestExceptions to HTTP 400 (i.e. BAD REQUEST)
-        if (exception instanceof BadRequestException)
+        final Response.Status httpStatus;
+        if (exception instanceof BadRequestException) {
             httpStatus = Response.Status.BAD_REQUEST;
-
-        //  Map NotFoundExceptions to HTTP 404 (i.e. NOT FOUND)
-        if (exception instanceof NotFoundException)
+        } else if (exception instanceof NotFoundException) {
             httpStatus = Response.Status.NOT_FOUND;
+        } else if (exception instanceof ForbiddenException) {
+            httpStatus = Response.Status.FORBIDDEN;
+        } else {
+            httpStatus = Response.Status.INTERNAL_SERVER_ERROR;
+        }
 
         //  Include exception message in response.
-        return Response.status(httpStatus).entity(exception.getMessage())
-                .build();
+        return Response.status(httpStatus)
+            .entity(new ApiResponseMessage(exception.getMessage()))
+            .build();
     }
 }

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
@@ -20,6 +20,7 @@ import com.hpe.caf.services.job.api.generated.model.Failure;
 import com.hpe.caf.services.job.api.generated.model.Job;
 import com.hpe.caf.services.configuration.AppConfig;
 import com.hpe.caf.services.job.exceptions.BadRequestException;
+import com.hpe.caf.services.job.exceptions.ForbiddenException;
 import com.hpe.caf.services.job.exceptions.NotFoundException;
 import com.hpe.caf.services.job.util.JobTaskId;
 import org.codehaus.jettison.json.JSONObject;
@@ -231,8 +232,9 @@ public final class DatabaseHelper
             if (sqlState.equals("02000")) {
                 //  Job id has not been provided.
                 throw new BadRequestException(se.getMessage());
-            }
-            else {
+            } else if (sqlState.equals("23505")) {
+                throw new ForbiddenException("Job already exists");
+            } else {
                 throw se;
             }
         }
@@ -278,8 +280,9 @@ public final class DatabaseHelper
             if (sqlState.equals("02000")) {
                 //  Job id has not been provided.
                 throw new BadRequestException(se.getMessage());
-            }
-            else {
+            } else if (sqlState.equals("23505")) {
+                throw new ForbiddenException("Job already exists");
+            } else {
                 throw se;
             }
         }

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobStatsApiServiceImpl.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobStatsApiServiceImpl.java
@@ -28,16 +28,8 @@ public class JobStatsApiServiceImpl extends JobStatsApiService {
     @Override
     public Response getJobStatsCount(final String partitionId, final String jobIdStartsWith, final String statusType, String cAFCorrelationId, SecurityContext securityContext)
             throws Exception {
-        try {
-            Long jobsCount = JobsStatsGetCount.getJobsCount(partitionId, jobIdStartsWith, statusType);
-            return Response.ok().entity(jobsCount).build();
-        } catch (BadRequestException e){
-            return Response.status(Response.Status.BAD_REQUEST).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (NotFoundException e){
-            return Response.status(Response.Status.NOT_FOUND).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (Exception e){
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(e.getMessage())).build();
-        }
+        Long jobsCount = JobsStatsGetCount.getJobsCount(partitionId, jobIdStartsWith, statusType);
+        return Response.ok().entity(jobsCount).build();
     }
 
 }

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiServiceImpl.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiServiceImpl.java
@@ -32,97 +32,53 @@ public class JobsApiServiceImpl extends JobsApiService {
     @Override
     public Response getJobs(final String partitionId, final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId, SecurityContext securityContext)
             throws Exception {
-        try {
-            Job[] jobs = JobsGet.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset);
-            return Response.ok().entity(jobs).build();
-        } catch (BadRequestException e){
-            return Response.status(Response.Status.BAD_REQUEST).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (NotFoundException e){
-            return Response.status(Response.Status.NOT_FOUND).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (Exception e){
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(e.getMessage())).build();
-        }
+        Job[] jobs = JobsGet.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset);
+        return Response.ok().entity(jobs).build();
     }
 
     @Override
     public Response getJob(final String partitionId, String jobId, String cAFCorrelationId, SecurityContext securityContext)
             throws Exception {
-        try {
-            Job job = JobsGetById.getJob(partitionId, jobId);
-            return Response.ok().entity(job).build();
-        } catch (BadRequestException e){
-            return Response.status(Response.Status.BAD_REQUEST).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (NotFoundException e){
-            return Response.status(Response.Status.NOT_FOUND).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (Exception e){
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(e.getMessage())).build();
-        }
+        Job job = JobsGetById.getJob(partitionId, jobId);
+        return Response.ok().entity(job).build();
     }
 
     @Override
     public Response createOrUpdateJob(final String partitionId, String jobId, NewJob newJob, String cAFCorrelationId, SecurityContext securityContext, UriInfo uriInfo)
             throws Exception {
-        try {
-            String createOrUpdate = JobsPut.createOrUpdateJob(partitionId, jobId, newJob);
-            if (createOrUpdate.equals("create")) {
-                //  Return HTTP 201 for successful create.
-                return Response.created(uriInfo.getRequestUri()).build();
-            } else {
-                //  Must be update - return HTTP 204 for successful update.
-                return Response.noContent().build();
-            }
-        } catch (BadRequestException e){
-            return Response.status(Response.Status.BAD_REQUEST).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (Exception e){
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(e.getMessage())).build();
+        String createOrUpdate = JobsPut.createOrUpdateJob(partitionId, jobId, newJob);
+        if (createOrUpdate.equals("create")) {
+            //  Return HTTP 201 for successful create.
+            return Response.created(uriInfo.getRequestUri()).build();
+        } else {
+            //  Must be update - return HTTP 204 for successful update.
+            return Response.noContent().build();
         }
     }
 
     @Override
     public Response deleteJob(final String partitionId, String jobId, String cAFCorrelationId, SecurityContext securityContext)
             throws Exception {
-        try {
-            JobsDelete.deleteJob(partitionId, jobId);
-            return Response.noContent().build();
-        } catch (BadRequestException e){
-            return Response.status(Response.Status.BAD_REQUEST).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (NotFoundException e){
-            return Response.status(Response.Status.NOT_FOUND).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (Exception e){
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(e.getMessage())).build();
-        }
+        JobsDelete.deleteJob(partitionId, jobId);
+        return Response.noContent().build();
     }
 
     @Override
     public Response cancelJob(final String partitionId, String jobId, String cAFCorrelationId, SecurityContext securityContext)
             throws Exception {
-        try {
-            JobsCancel.cancelJob(partitionId, jobId);
-            return Response.noContent().build();
-        } catch (BadRequestException e){
-            return Response.status(Response.Status.BAD_REQUEST).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (NotFoundException e){
-            return Response.status(Response.Status.NOT_FOUND).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (Exception e){
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(e.getMessage())).build();
-        }
+        JobsCancel.cancelJob(partitionId, jobId);
+        return Response.noContent().build();
     }
 
     @Override
     public Response getJobActive(final String partitionId, String jobId, String cAFCorrelationId, SecurityContext securityContext)
             throws Exception {
-        try {
-            JobsActive.JobsActiveResult result = JobsActive.isJobActive(partitionId, jobId);
+        JobsActive.JobsActiveResult result = JobsActive.isJobActive(partitionId, jobId);
 
-            CacheControl cc = new CacheControl();
-            cc.setMaxAge(result.statusCheckIntervalSecs);
+        CacheControl cc = new CacheControl();
+        cc.setMaxAge(result.statusCheckIntervalSecs);
 
-            return Response.ok().header("CacheableJobStatus", true).entity(result.active).cacheControl(cc).build();
-        } catch (BadRequestException e){
-            return Response.status(Response.Status.BAD_REQUEST).entity(new ApiResponseMessage(e.getMessage())).build();
-        } catch (Exception e){
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(e.getMessage())).build();
-        }
+        return Response.ok().header("CacheableJobStatus", true).entity(result.active).cacheControl(cc).build();
     }
 
 }

--- a/job-service/src/main/java/com/hpe/caf/services/job/exceptions/ForbiddenException.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/exceptions/ForbiddenException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2018 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.services.job.exceptions;
+
+/**
+ * Custom exception implemented for the job service api. Exceptions of this type map
+ * directly onto http 403 status codes.
+ */
+public final class ForbiddenException extends Exception {
+
+    public ForbiddenException(final String message) {
+        super(message);
+    }
+
+    public ForbiddenException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}


### PR DESCRIPTION
In adding `ForbiddenException`, I cleaned up the error handling a bit.  Not sure why we were mapping errors manually when the `ExceptionMapper` was already set up.

----

- ticket: https://portal.digitalsafe.net/browse/SCMOD-6619
- build: http://sou-jenkins2.hpeswlab.net/job/JobService/job/JobService~job-service~SCMOD-6619~CI/