### PR TITLE
SCMOD-7309: Add NotFinished job status filter

### DIFF
--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -72,12 +72,13 @@ paths:
         in: query
         type: string
         required: false
-        description: All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned.
+        description: All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned; NotFinished - only those results with unfinished statuses (ie. Active, Paused, Waiting) will be returned.
         enum:
           - All
           - NotCompleted
           - Completed
           - Inactive
+          - NotFinished
       - name: limit
         in: query
         type: integer
@@ -231,12 +232,13 @@ paths:
         in: query
         type: string
         required: false
-        description: All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned.
+        description: All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned; NotFinished - only those results with unfinished statuses (ie. Active, Paused, Waiting) will be returned.
         enum:
           - All
           - NotCompleted
           - Completed
           - Inactive
+          - NotFinished
     get:
       tags:
         - Jobs

--- a/job-service-db/src/main/resources/procedures/getJobs.sql
+++ b/job-service-db/src/main/resources/procedures/getJobs.sql
@@ -59,6 +59,7 @@ BEGIN
     --      NotCompleted - only those results with statuses other than Completed will be returned;
     --      Completed - only those results with Completed status will be returned;
     --      Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned;
+    --      NotFinished - only those results with unfinished statuses (ie. Active, Paused, Waiting) will be returned;
     --      Anything else returns all statuses.
     -- Also accepts in_limit and in_offset params to support paging and limiting the number of rows returned.
     -- 'WORKER' is the only supported action type for now and this is returned.
@@ -94,6 +95,9 @@ BEGIN
             whereOrAnd := andConst;
         ELSIF in_status_type = 'Inactive' THEN
             sql := sql || whereOrAnd || $q$ status IN ('Completed', 'Cancelled', 'Failed')$q$;
+            whereOrAnd := andConst;
+        ELSIF in_status_type = 'NotFinished' THEN
+            sql := sql || whereOrAnd || $q$ status IN ('Active', 'Paused', 'Waiting')$q$;
             whereOrAnd := andConst;
         END IF;
     END IF;

--- a/job-service-db/src/main/resources/procedures/getJobsCount.sql
+++ b/job-service-db/src/main/resources/procedures/getJobsCount.sql
@@ -43,6 +43,7 @@ BEGIN
     --      NotCompleted - only those results with statuses other than Completed will be returned;
     --      Completed - only those results with Completed status will be returned;
     --      Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned;
+    --      NotFinished - only those results with unfinished statuses (ie. Active, Paused, Waiting) will be returned;
     --      Anything else returns all statuses.
     sql := $q$SELECT COUNT(job.job_id) FROM job$q$;
 
@@ -65,6 +66,9 @@ BEGIN
             whereOrAnd := andConst;
         ELSIF in_status_type = 'Inactive' THEN
             sql := sql || whereOrAnd || $q$ status IN ('Completed', 'Cancelled', 'Failed')$q$;
+            whereOrAnd := andConst;
+        ELSIF in_status_type = 'NotFinished' THEN
+            sql := sql || whereOrAnd || $q$ status IN ('Active', 'Paused', 'Waiting')$q$;
             whereOrAnd := andConst;
         END IF;
     END IF;

--- a/job-service-db/src/main/resources/v3.1.0/changelog.xml
+++ b/job-service-db/src/main/resources/v3.1.0/changelog.xml
@@ -39,4 +39,13 @@
                          path="procedures/createJobForDependencies.sql" />
     </changeSet>
 
+    <changeSet id="update_procedures_add_not_finished_filter" author="Gamma Team">
+        <createProcedure schemaName="public"
+                         procedureName="get_jobs_count"
+                         path="procedures/getJobsCount.sql" />
+        <createProcedure schemaName="public"
+                         procedureName="get_jobs"
+                         path="procedures/getJobs.sql" />
+    </changeSet>
+
 </databaseChangeLog>

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
@@ -47,7 +47,7 @@ public class JobsApi  {
     public Response getJobs(
             @ApiParam(value = "Only allow access to jobs in the container with this name",required=true) @PathParam("partitionId") String partitionId,
             @ApiParam(value = "Only those results whose job id starts with this value will be returned") @QueryParam("jobIdStartsWith") String jobIdStartsWith,
-            @ApiParam(value = "All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned.") @QueryParam("statusType") String statusType,
+            @ApiParam(value = "All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned; NotFinished - only those results with unfinished statuses (ie. Active, Paused, Waiting) will be returned.") @QueryParam("statusType") String statusType,
             @ApiParam(value = "The maximum results to return (i.e. page size)") @QueryParam("limit") Integer limit,
             @ApiParam(value = "The starting position from which to return results (useful for paging)") @QueryParam("offset") Integer offset,
             @ApiParam(value = "An identifier that can be used to correlate events that occurred\nacross different CAF services" )@HeaderParam("CAF-Correlation-Id") String cAFCorrelationId,@Context SecurityContext securityContext)
@@ -165,7 +165,7 @@ public class JobsApi  {
     public Response getJobStatsCount(
         @ApiParam(value = "Only allow access to jobs in the container with this name",required=true) @PathParam("partitionId") String partitionId,
         @ApiParam(value = "Only those results whose job id starts with this value will be returned") @QueryParam("jobIdStartsWith") String jobIdStartsWith,
-        @ApiParam(value = "All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned.") @QueryParam("statusType") String statusType,
+        @ApiParam(value = "All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned; NotFinished - only those results with unfinished statuses (ie. Active, Paused, Waiting) will be returned.") @QueryParam("statusType") String statusType,
         @ApiParam(value = "An identifier that can be used to correlate events that occurred\nacross different CAF services" )@HeaderParam("CAF-Correlation-Id") String cAFCorrelationId,@Context SecurityContext securityContext)
         throws Exception {
         return statsDelegate.getJobStatsCount(partitionId, jobIdStartsWith, statusType, cAFCorrelationId,securityContext);

--- a/release-notes-3.1.0.md
+++ b/release-notes-3.1.0.md
@@ -7,5 +7,7 @@ ${version-number}
 
 - [SCMOD-6955](https://portal.digitalsafe.net/browse/SCMOD-6955): Job types  
        Job types can be defined, and new jobs can target a type to use a well-defined, type-specific input format.
+- [SCMOD-7309](https://portal.digitalsafe.net/browse/SCMOD-7309) NotFinished job status filter  
+        The statusType parameter accepts a new value, which includes only jobs which haven't reached a final state.
 
 #### Known Issues


### PR DESCRIPTION
This is for the classification stuff, to deal with (hopefully rare anyway) hanging jobs (see SCMOD-7312).  'Inactive' and 'completed' already have other meanings, so I used 'finished'.

- ticket: https://portal.digitalsafe.net/browse/SCMOD-7309
- build: http://sou-jenkins2.hpeswlab.net/job/JobService/job/JobService~job-service~SCMOD-7309~CI/