### PR TITLE
SCMOD-7308: Allow sorting a job listing

### DIFF
--- a/job-service-container/src/integration-test/java/com/hpe/caf/services/job/api/JobServiceIT.java
+++ b/job-service-container/src/integration-test/java/com/hpe/caf/services/job/api/JobServiceIT.java
@@ -478,7 +478,7 @@ public class JobServiceIT {
         final String job3Id = createJob(jobId + "b");
 
         final List<Job> jobs = jobsApi.getJobs(
-            defaultPartitionId, "1", null, null, null, null, "JOB_ID:ASCENDING");
+            defaultPartitionId, "1", null, null, null, null, "jobId:asc");
         final List<String> resultJobIds =
             jobs.stream().map(job -> job.getId()).collect(Collectors.toList());
         assertEquals(resultJobIds, Arrays.asList(jobId + "A", jobId + "b", jobId + "C"),

--- a/job-service-container/src/integration-test/java/com/hpe/caf/services/job/api/JobServiceIT.java
+++ b/job-service-container/src/integration-test/java/com/hpe/caf/services/job/api/JobServiceIT.java
@@ -416,7 +416,7 @@ public class JobServiceIT {
         }
 
         List<Job> retrievedJobs = jobsApi.getJobs(
-            defaultPartitionId, "100",null,null,null,null,null,null);
+            defaultPartitionId, "100",null,null,null,null,null);
         assertEquals(retrievedJobs.size(), 10);
 
         for(int i=0; i<10; i++) {
@@ -447,7 +447,7 @@ public class JobServiceIT {
         jobsApi.createOrUpdateJob(defaultPartitionId, waitingJobId, waitingJob, correlationId);
 
         final List<Job> jobs = jobsApi.getJobs(
-            defaultPartitionId, correlationId, null, "NotFinished", null, null, null, null);
+            defaultPartitionId, correlationId, null, "NotFinished", null, null, null);
         assertEquals(jobs.size(), 1);
         assertEquals(jobs.get(0).getId(), waitingJobId);
     }
@@ -471,33 +471,18 @@ public class JobServiceIT {
     }
 
     @Test
-    public void testGetJobsWithSortField() throws ApiException {
+    public void testGetJobsWithSort() throws ApiException {
         final String jobId = UUID.randomUUID().toString();
         final String job1Id = createJob(jobId + "C");
         final String job2Id = createJob(jobId + "A");
         final String job3Id = createJob(jobId + "b");
 
         final List<Job> jobs = jobsApi.getJobs(
-            defaultPartitionId, "1", null, null, null, null, "JOB_ID", null);
+            defaultPartitionId, "1", null, null, null, null, "JOB_ID:ASCENDING");
         final List<String> resultJobIds =
             jobs.stream().map(job -> job.getId()).collect(Collectors.toList());
         assertEquals(resultJobIds, Arrays.asList(jobId + "A", jobId + "b", jobId + "C"),
             "should sort case-insensitively by ascending job ID");
-    }
-
-    @Test
-    public void testGetJobsWithSortOrder() throws ApiException {
-        final String jobId = UUID.randomUUID().toString();
-        final String job1Id = createJob(jobId + "C");
-        final String job2Id = createJob(jobId + "A");
-        final String job3Id = createJob(jobId + "b");
-
-        final List<Job> jobs = jobsApi.getJobs(
-            defaultPartitionId, "1", null, null, null, null, "JOB_ID", "DESCENDING");
-        final List<String> resultJobIds =
-            jobs.stream().map(job -> job.getId()).collect(Collectors.toList());
-        assertEquals(resultJobIds, Arrays.asList(jobId + "C", jobId + "b", jobId + "A"),
-            "should sort case-insensitively by descending job ID");
     }
 
     @Test
@@ -642,7 +627,7 @@ public class JobServiceIT {
 
         jobsApi.createOrUpdateJob(defaultPartitionId, jobId, newJob, jobCorrelationId);
         final List<Job> jobs = jobsApi.getJobs(
-            UUID.randomUUID().toString(), jobCorrelationId, null, null, null, null, null, null);
+            UUID.randomUUID().toString(), jobCorrelationId, null, null, null, null, null);
         assertEquals(jobs.size(), 0, "job list should be empty");
     }
 

--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -91,6 +91,24 @@ paths:
         format: int32
         required: false
         description: The starting position from which to return results (useful for paging)
+      - name: sortField
+        in: query
+        type: string
+        required: false
+        description: The field to sort the returned results by
+        default: CREATE_DATE
+        enum:
+          - JOB_ID
+          - CREATE_DATE
+      - name: sortOrder
+        in: query
+        type: string
+        required: false
+        description: The direction in which the returned results are sorted with respect to sortField. If sortField is not specified, then the default value is DESCENDING
+        default: ASCENDING
+        enum:
+          - ASCENDING
+          - DESCENDING
     get:
       tags:
         - Jobs

--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -91,24 +91,12 @@ paths:
         format: int32
         required: false
         description: The starting position from which to return results (useful for paging)
-      - name: sortField
+      - name: sort
         in: query
         type: string
         required: false
-        description: The field to sort the returned results by
-        default: CREATE_DATE
-        enum:
-          - JOB_ID
-          - CREATE_DATE
-      - name: sortOrder
-        in: query
-        type: string
-        required: false
-        description: The direction in which the returned results are sorted with respect to sortField. If sortField is not specified, then the default value is DESCENDING
-        default: ASCENDING
-        enum:
-          - ASCENDING
-          - DESCENDING
+        description: 'How to order the returned results, in the format <field>:<direction>.  Allowed values for field: JOB_ID, CREATE_DATE.  Allowed values for direction: ASCENDING, DESCENDING.'
+        default: CREATE_DATE:DESCENDING
     get:
       tags:
         - Jobs

--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -95,8 +95,8 @@ paths:
         in: query
         type: string
         required: false
-        description: 'How to order the returned results, in the format <field>:<direction>.  Allowed values for field: JOB_ID, CREATE_DATE.  Allowed values for direction: ASCENDING, DESCENDING.'
-        default: CREATE_DATE:DESCENDING
+        description: 'How to order the returned results, in the format <field>:<direction>.  Allowed values for field: jobId, createTime.  Allowed values for direction: asc, desc.'
+        default: createTime:desc
     get:
       tags:
         - Jobs

--- a/job-service-db/src/main/resources/procedures/getJobs.sql
+++ b/job-service-db/src/main/resources/procedures/getJobs.sql
@@ -19,6 +19,9 @@
  *
  *  Description:
  *  Returns the list of job definitions in the system.
+ *
+ * in_sort_field: name of the column to sort by
+ * in_sort_ascending: true to sort ascending, false to sort descending
  */
 DROP FUNCTION IF EXISTS get_jobs(
     in_job_id_starts_with VARCHAR(58),
@@ -30,7 +33,9 @@ CREATE OR REPLACE FUNCTION get_jobs(
     in_job_id_starts_with VARCHAR(48),
     in_status_type VARCHAR(20),
     in_limit INT,
-    in_offset INT
+    in_offset INT,
+    in_sort_field VARCHAR(20),
+    in_sort_ascending BOOLEAN
 )
 RETURNS TABLE(
     job_id VARCHAR(48),
@@ -102,7 +107,8 @@ BEGIN
         END IF;
     END IF;
 
-    sql := sql || ' ORDER BY create_date DESC';
+    sql := sql || ' ORDER BY ' || quote_ident(in_sort_field) ||
+        ' ' || CASE WHEN in_sort_ascending THEN 'ASC' ELSE 'DESC' END;
 
     IF in_limit > 0 THEN
         sql := sql || ' LIMIT ' || in_limit;

--- a/job-service-db/src/main/resources/v3.1.0/changelog.xml
+++ b/job-service-db/src/main/resources/v3.1.0/changelog.xml
@@ -48,4 +48,13 @@
                          path="procedures/getJobs.sql" />
     </changeSet>
 
+    <changeSet id="add_job_sorting" author="Gamma Team">
+        <createProcedure schemaName="public"
+                         procedureName="get_jobs"
+                         path="procedures/getJobs.sql" />
+        <createIndex schemaName="public" tableName="job" indexName="idx_job_create_date">
+            <column name="create_date" />
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
@@ -19,6 +19,8 @@ import com.hpe.caf.services.db.client.DatabaseConnectionProvider;
 import com.hpe.caf.services.job.api.generated.model.Failure;
 import com.hpe.caf.services.job.api.generated.model.Job;
 import com.hpe.caf.services.configuration.AppConfig;
+import com.hpe.caf.services.job.api.generated.model.JobSortField;
+import com.hpe.caf.services.job.api.generated.model.JobSortOrder;
 import com.hpe.caf.services.job.exceptions.BadRequestException;
 import com.hpe.caf.services.job.exceptions.ForbiddenException;
 import com.hpe.caf.services.job.exceptions.NotFoundException;
@@ -58,13 +60,13 @@ public final class DatabaseHelper
     /**
      * Returns a list of job definitions in the system.
      */
-    public Job[] getJobs(final String partitionId, String jobIdStartsWith, String statusType, Integer limit, Integer offset) throws Exception {
+    public Job[] getJobs(final String partitionId, String jobIdStartsWith, String statusType, Integer limit, Integer offset, final JobSortField sortField, final JobSortOrder sortOrder) throws Exception {
 
         List<Job> jobs=new ArrayList<>();
 
         try (
                 Connection conn = DatabaseConnectionProvider.getConnection(appConfig);
-                CallableStatement stmt = conn.prepareCall("{call get_jobs(?,?,?,?,?)}")
+                CallableStatement stmt = conn.prepareCall("{call get_jobs(?,?,?,?,?,?,?)}")
         ) {
             if (jobIdStartsWith == null) {
                 jobIdStartsWith = "";
@@ -83,6 +85,8 @@ public final class DatabaseHelper
             stmt.setString(3, statusType);
             stmt.setInt(4, limit);
             stmt.setInt(5, offset);
+            stmt.setString(6, sortField.getDbField());
+            stmt.setBoolean(7, sortOrder.getDbValue());
 
             //  Execute a query to return a list of all job definitions in the system.
             LOG.debug("Calling get_jobs() database function...");

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
@@ -20,7 +20,7 @@ import com.hpe.caf.services.job.api.generated.model.Failure;
 import com.hpe.caf.services.job.api.generated.model.Job;
 import com.hpe.caf.services.configuration.AppConfig;
 import com.hpe.caf.services.job.api.generated.model.JobSortField;
-import com.hpe.caf.services.job.api.generated.model.JobSortOrder;
+import com.hpe.caf.services.job.api.generated.model.SortDirection;
 import com.hpe.caf.services.job.exceptions.BadRequestException;
 import com.hpe.caf.services.job.exceptions.ForbiddenException;
 import com.hpe.caf.services.job.exceptions.NotFoundException;
@@ -60,7 +60,7 @@ public final class DatabaseHelper
     /**
      * Returns a list of job definitions in the system.
      */
-    public Job[] getJobs(final String partitionId, String jobIdStartsWith, String statusType, Integer limit, Integer offset, final JobSortField sortField, final JobSortOrder sortOrder) throws Exception {
+    public Job[] getJobs(final String partitionId, String jobIdStartsWith, String statusType, Integer limit, Integer offset, final JobSortField sortField, final SortDirection sortDirection) throws Exception {
 
         List<Job> jobs=new ArrayList<>();
 
@@ -86,7 +86,7 @@ public final class DatabaseHelper
             stmt.setInt(4, limit);
             stmt.setInt(5, offset);
             stmt.setString(6, sortField.getDbField());
-            stmt.setBoolean(7, sortOrder.getDbValue());
+            stmt.setBoolean(7, sortDirection.getDbValue());
 
             //  Execute a query to return a list of all job definitions in the system.
             LOG.debug("Calling get_jobs() database function...");

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/JobsGet.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/JobsGet.java
@@ -60,14 +60,12 @@ public final class JobsGet {
                 if (sortParts.length != 2) {
                     throw new BadRequestException("Invalid format for sort: " + sort);
                 }
-                try {
-                    sortField = JobSortField.valueOf(sortParts[0]);
-                } catch (final IllegalArgumentException e) {
+                sortField = JobSortField.fromApiValue(sortParts[0]);
+                if (sortField == null) {
                     throw new BadRequestException("Invalid value for sort field: " + sortParts[0]);
                 }
-                try {
-                    sortDirection = SortDirection.valueOf(sortParts[1]);
-                } catch (final IllegalArgumentException e) {
+                sortDirection = SortDirection.fromApiValue(sortParts[1]);
+                if (sortDirection == null) {
                     throw new BadRequestException(
                         "Invalid value for sort direction: " + sortParts[1]);
                 }

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
@@ -51,7 +51,7 @@ public class JobsApi  {
             @ApiParam(value = "The maximum results to return (i.e. page size)") @QueryParam("limit") Integer limit,
             @ApiParam(value = "The starting position from which to return results (useful for paging)") @QueryParam("offset") Integer offset,
             @ApiParam(value = "An identifier that can be used to correlate events that occurred\nacross different CAF services" )@HeaderParam("CAF-Correlation-Id") String cAFCorrelationId,
-            @ApiParam(value = "How to order the returned results, in the format <field>:<direction>.  Allowed values for field: JOB_ID, CREATE_DATE.  Allowed values for direction: ASCENDING, DESCENDING.") @QueryParam("sort") String sort,
+            @ApiParam(value = "How to order the returned results, in the format <field>:<direction>.  Allowed values for field: jobId, createTime.  Allowed values for direction: asc, desc.") @QueryParam("sort") String sort,
             @Context SecurityContext securityContext)
             throws Exception {
         return delegate.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset, cAFCorrelationId, sort, securityContext);

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
@@ -50,9 +50,12 @@ public class JobsApi  {
             @ApiParam(value = "All - no status filter is applied (Default); NotCompleted - only those results with statuses other than Completed will be returned; Completed - only those results with Completed status will be returned; Inactive - only those results with inactive statuses (i.e. Completed, Failed, Cancelled) will be returned; NotFinished - only those results with unfinished statuses (ie. Active, Paused, Waiting) will be returned.") @QueryParam("statusType") String statusType,
             @ApiParam(value = "The maximum results to return (i.e. page size)") @QueryParam("limit") Integer limit,
             @ApiParam(value = "The starting position from which to return results (useful for paging)") @QueryParam("offset") Integer offset,
-            @ApiParam(value = "An identifier that can be used to correlate events that occurred\nacross different CAF services" )@HeaderParam("CAF-Correlation-Id") String cAFCorrelationId,@Context SecurityContext securityContext)
+            @ApiParam(value = "An identifier that can be used to correlate events that occurred\nacross different CAF services" )@HeaderParam("CAF-Correlation-Id") String cAFCorrelationId,
+            @ApiParam(value = "The field to sort the returned results by") @QueryParam("sortField") String sortField,
+            @ApiParam(value = "The direction in which the returned results are sorted with respect to sortField. If sortField is not specified, then the default value is DESCENDING") @QueryParam("sortOrder") String sortOrder,
+            @Context SecurityContext securityContext)
             throws Exception {
-        return delegate.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset, cAFCorrelationId,securityContext);
+        return delegate.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset, cAFCorrelationId, sortField, sortOrder, securityContext);
     }
 
     @GET

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApi.java
@@ -51,11 +51,10 @@ public class JobsApi  {
             @ApiParam(value = "The maximum results to return (i.e. page size)") @QueryParam("limit") Integer limit,
             @ApiParam(value = "The starting position from which to return results (useful for paging)") @QueryParam("offset") Integer offset,
             @ApiParam(value = "An identifier that can be used to correlate events that occurred\nacross different CAF services" )@HeaderParam("CAF-Correlation-Id") String cAFCorrelationId,
-            @ApiParam(value = "The field to sort the returned results by") @QueryParam("sortField") String sortField,
-            @ApiParam(value = "The direction in which the returned results are sorted with respect to sortField. If sortField is not specified, then the default value is DESCENDING") @QueryParam("sortOrder") String sortOrder,
+            @ApiParam(value = "How to order the returned results, in the format <field>:<direction>.  Allowed values for field: JOB_ID, CREATE_DATE.  Allowed values for direction: ASCENDING, DESCENDING.") @QueryParam("sort") String sort,
             @Context SecurityContext securityContext)
             throws Exception {
-        return delegate.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset, cAFCorrelationId, sortField, sortOrder, securityContext);
+        return delegate.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset, cAFCorrelationId, sort, securityContext);
     }
 
     @GET

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiService.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiService.java
@@ -24,7 +24,7 @@ import com.hpe.caf.services.job.api.generated.model.NewJob;
 @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJerseyServerCodegen", date = "2016-02-29T10:25:31.219Z")
 public abstract class JobsApiService {
 
-      public abstract Response getJobs(String partitionId,final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId,SecurityContext securityContext)
+      public abstract Response getJobs(String partitionId,final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId, String sortField, String sortOrder,SecurityContext securityContext)
               throws Exception;
 
       public abstract Response getJob(String partitionId,String jobId,String cAFCorrelationId,SecurityContext securityContext)

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiService.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiService.java
@@ -24,7 +24,7 @@ import com.hpe.caf.services.job.api.generated.model.NewJob;
 @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJerseyServerCodegen", date = "2016-02-29T10:25:31.219Z")
 public abstract class JobsApiService {
 
-      public abstract Response getJobs(String partitionId,final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId, String sortField, String sortOrder,SecurityContext securityContext)
+      public abstract Response getJobs(String partitionId,final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId, String sort,SecurityContext securityContext)
               throws Exception;
 
       public abstract Response getJob(String partitionId,String jobId,String cAFCorrelationId,SecurityContext securityContext)

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiServiceImpl.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiServiceImpl.java
@@ -30,9 +30,9 @@ import javax.ws.rs.core.UriInfo;
 public class JobsApiServiceImpl extends JobsApiService {
 
     @Override
-    public Response getJobs(final String partitionId, final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId, String sortField, String sortOrder, SecurityContext securityContext)
+    public Response getJobs(final String partitionId, final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId, String sort, SecurityContext securityContext)
             throws Exception {
-        Job[] jobs = JobsGet.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset, sortField, sortOrder);
+        Job[] jobs = JobsGet.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset, sort);
         return Response.ok().entity(jobs).build();
     }
 

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiServiceImpl.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/JobsApiServiceImpl.java
@@ -30,9 +30,9 @@ import javax.ws.rs.core.UriInfo;
 public class JobsApiServiceImpl extends JobsApiService {
 
     @Override
-    public Response getJobs(final String partitionId, final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId, SecurityContext securityContext)
+    public Response getJobs(final String partitionId, final String jobIdStartsWith, final String statusType, final Integer limit, final Integer offset, String cAFCorrelationId, String sortField, String sortOrder, SecurityContext securityContext)
             throws Exception {
-        Job[] jobs = JobsGet.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset);
+        Job[] jobs = JobsGet.getJobs(partitionId, jobIdStartsWith, statusType, limit, offset, sortField, sortOrder);
         return Response.ok().entity(jobs).build();
     }
 

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/JobSortField.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/JobSortField.java
@@ -22,11 +22,6 @@ public enum JobSortField {
     JOB_ID("job_id"),
     CREATE_DATE("create_date");
 
-    /**
-     * The field that should be used to sort by default.
-     */
-    public final static JobSortField DEFAULT = CREATE_DATE;
-
     private final String dbField;
 
     JobSortField(final String dbField) {

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/JobSortField.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/JobSortField.java
@@ -15,17 +15,45 @@
  */
 package com.hpe.caf.services.job.api.generated.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Fields a list of jobs can be sorted by.
  */
 public enum JobSortField {
-    JOB_ID("job_id"),
-    CREATE_DATE("create_date");
+    JOB_ID("jobId", "job_id"),
+    CREATE_DATE("createTime", "create_date");
 
+    private static final Map<String, JobSortField> apiValueLookup = new HashMap<>();
+
+    private final String apiValue;
     private final String dbField;
 
-    JobSortField(final String dbField) {
+    static {
+        for (final JobSortField field : values()) {
+            apiValueLookup.put(field.apiValue, field);
+        }
+    }
+
+    JobSortField(final String apiValue, final String dbField) {
+        this.apiValue = apiValue;
         this.dbField = dbField;
+    }
+
+    /**
+     * @param apiValue Public identifier for this field
+     * @return The matching field, or null
+     */
+    public static JobSortField fromApiValue(final String apiValue) {
+        return apiValueLookup.get(apiValue);
+    }
+
+    /**
+     * @return Public identifier for this field
+     */
+    public String getApiValue() {
+        return apiValue;
     }
 
     /**

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/JobSortField.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/JobSortField.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2018 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.services.job.api.generated.model;
+
+/**
+ * Fields a list of jobs can be sorted by.
+ */
+public enum JobSortField {
+    JOB_ID("job_id"),
+    CREATE_DATE("create_date");
+
+    /**
+     * The field that should be used to sort by default.
+     */
+    public final static JobSortField DEFAULT = CREATE_DATE;
+
+    private final String dbField;
+
+    JobSortField(final String dbField) {
+        this.dbField = dbField;
+    }
+
+    /**
+     * @return Database column name corresponding to this field.
+     */
+    public String getDbField() {
+        return dbField;
+    }
+
+}

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/JobSortOrder.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/JobSortOrder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2018 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.services.job.api.generated.model;
+
+/**
+ * Directions a list of jobs can be sorted in.
+ */
+public enum JobSortOrder {
+    ASCENDING(true),
+    DESCENDING(false);
+
+    private final boolean dbValue;
+
+    JobSortOrder(final boolean dbValue) {
+        this.dbValue = dbValue;
+    }
+
+    /**
+     * @param sortFieldProvided Whether a {@link JobSortField} was provided
+     * @return The sort order that should be used to sort by default
+     */
+    public static JobSortOrder getDefault(final boolean sortFieldProvided) {
+        return sortFieldProvided ? ASCENDING : DESCENDING;
+    }
+
+    /**
+     * @return Value as accepted by database stored procedures (true for ascending, false for
+     *         descending)
+     */
+    public boolean getDbValue() {
+        return dbValue;
+    }
+
+}

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/SortDirection.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/SortDirection.java
@@ -15,17 +15,45 @@
  */
 package com.hpe.caf.services.job.api.generated.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Directions a list can be sorted in.
  */
 public enum SortDirection {
-    ASCENDING(true),
-    DESCENDING(false);
+    ASCENDING("asc", true),
+    DESCENDING("desc", false);
 
+    private static final Map<String, SortDirection> apiValueLookup = new HashMap<>();
+
+    private final String apiValue;
     private final boolean dbValue;
 
-    SortDirection(final boolean dbValue) {
+    static {
+        for (final SortDirection direction : values()) {
+            apiValueLookup.put(direction.apiValue, direction);
+        }
+    }
+
+    SortDirection(final String apiValue, final boolean dbValue) {
+        this.apiValue = apiValue;
         this.dbValue = dbValue;
+    }
+
+    /**
+     * @param apiValue Public identifier for this sort direction
+     * @return The matching sort direction, or null
+     */
+    public static SortDirection fromApiValue(final String apiValue) {
+        return apiValueLookup.get(apiValue);
+    }
+
+    /**
+     * @return Public identifier for this sort direction
+     */
+    public String getApiValue() {
+        return apiValue;
     }
 
     /**

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/SortDirection.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/SortDirection.java
@@ -16,24 +16,16 @@
 package com.hpe.caf.services.job.api.generated.model;
 
 /**
- * Directions a list of jobs can be sorted in.
+ * Directions a list can be sorted in.
  */
-public enum JobSortOrder {
+public enum SortDirection {
     ASCENDING(true),
     DESCENDING(false);
 
     private final boolean dbValue;
 
-    JobSortOrder(final boolean dbValue) {
+    SortDirection(final boolean dbValue) {
         this.dbValue = dbValue;
-    }
-
-    /**
-     * @param sortFieldProvided Whether a {@link JobSortField} was provided
-     * @return The sort order that should be used to sort by default
-     */
-    public static JobSortOrder getDefault(final boolean sortFieldProvided) {
-        return sortFieldProvided ? ASCENDING : DESCENDING;
     }
 
     /**

--- a/job-service/src/test/java/com/hpe/caf/services/job/api/JobsGetTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/api/JobsGetTest.java
@@ -16,6 +16,8 @@
 package com.hpe.caf.services.job.api;
 
 import com.hpe.caf.services.configuration.AppConfig;
+import com.hpe.caf.services.job.api.generated.model.JobSortField;
+import com.hpe.caf.services.job.api.generated.model.JobSortOrder;
 import com.hpe.caf.services.job.exceptions.BadRequestException;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,14 +56,43 @@ public final class JobsGetTest {
     @Test
     public void testGetJob_Success() throws Exception {
         //  Test successful run of job retrieval.
-        JobsGet.getJobs("partition", "", null, 0, 0);
+        JobsGet.getJobs("partition", "", null, 0, 0, null, null);
 
-        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs("partition", "", null, 0, 0);
+        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
+            "partition", "", null, 0, 0, JobSortField.CREATE_DATE, JobSortOrder.DESCENDING);
     }
 
     @Test(expected = BadRequestException.class)
-    public void testGetJobs_Success_EmptyPartitionId() throws Exception {
-        JobsGet.getJobs("", "", null, 0, 0);
+    public void testGetJobs_Failure_EmptyPartitionId() throws Exception {
+        JobsGet.getJobs("", "", null, 0, 0, null, null);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testGetJobs_Failure_InvalidSortField() throws Exception {
+        JobsGet.getJobs("partition", "", null, 0, 0, "unknown", null);
+    }
+
+    public void testGetJobs_Success_WithSortField() throws Exception {
+        JobsGet.getJobs("partition", "", null, 0, 0, "JOB_ID", null);
+        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
+            "partition", "", null, 0, 0, JobSortField.JOB_ID, JobSortOrder.ASCENDING);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testGetJobs_Failure_InvalidSortOrder() throws Exception {
+        JobsGet.getJobs("partition", "", null, 0, 0, null, "random");
+    }
+
+    public void testGetJobs_Success_WithSortOrder() throws Exception {
+        JobsGet.getJobs("partition", "", null, 0, 0, null, "ASCENDING");
+        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
+            "partition", "", null, 0, 0, JobSortField.CREATE_DATE, JobSortOrder.ASCENDING);
+    }
+
+    public void testGetJobs_Success_WithSortFieldAndSortOrder() throws Exception {
+        JobsGet.getJobs("partition", "", null, 0, 0, "JOB_ID", "DESCENDING");
+        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
+            "partition", "", null, 0, 0, JobSortField.JOB_ID, JobSortOrder.DESCENDING);
     }
 
 }

--- a/job-service/src/test/java/com/hpe/caf/services/job/api/JobsGetTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/api/JobsGetTest.java
@@ -69,7 +69,7 @@ public final class JobsGetTest {
 
     @Test
     public void testGetJobs_Success_WithSort() throws Exception {
-        JobsGet.getJobs("partition", "", null, 0, 0, "JOB_ID:ASCENDING");
+        JobsGet.getJobs("partition", "", null, 0, 0, "jobId:asc");
         Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
             "partition", "", null, 0, 0, JobSortField.JOB_ID, SortDirection.ASCENDING);
     }
@@ -81,12 +81,12 @@ public final class JobsGetTest {
 
     @Test(expected = BadRequestException.class)
     public void testGetJobs_Failure_InvalidSortField() throws Exception {
-        JobsGet.getJobs("partition", "", null, 0, 0, "UNKNOWN:DESCENDING");
+        JobsGet.getJobs("partition", "", null, 0, 0, "unknown:desc");
     }
 
     @Test(expected = BadRequestException.class)
     public void testGetJobs_Failure_InvalidSortDirection() throws Exception {
-        JobsGet.getJobs("partition", "", null, 0, 0, "JOB_ID:RANDOM");
+        JobsGet.getJobs("partition", "", null, 0, 0, "jobId:random");
     }
 
 }

--- a/job-service/src/test/java/com/hpe/caf/services/job/api/JobsGetTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/api/JobsGetTest.java
@@ -17,7 +17,7 @@ package com.hpe.caf.services.job.api;
 
 import com.hpe.caf.services.configuration.AppConfig;
 import com.hpe.caf.services.job.api.generated.model.JobSortField;
-import com.hpe.caf.services.job.api.generated.model.JobSortOrder;
+import com.hpe.caf.services.job.api.generated.model.SortDirection;
 import com.hpe.caf.services.job.exceptions.BadRequestException;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,43 +56,37 @@ public final class JobsGetTest {
     @Test
     public void testGetJob_Success() throws Exception {
         //  Test successful run of job retrieval.
-        JobsGet.getJobs("partition", "", null, 0, 0, null, null);
+        JobsGet.getJobs("partition", "", null, 0, 0, null);
 
         Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
-            "partition", "", null, 0, 0, JobSortField.CREATE_DATE, JobSortOrder.DESCENDING);
+            "partition", "", null, 0, 0, JobSortField.CREATE_DATE, SortDirection.DESCENDING);
     }
 
     @Test(expected = BadRequestException.class)
     public void testGetJobs_Failure_EmptyPartitionId() throws Exception {
-        JobsGet.getJobs("", "", null, 0, 0, null, null);
+        JobsGet.getJobs("", "", null, 0, 0, null);
+    }
+
+    @Test
+    public void testGetJobs_Success_WithSort() throws Exception {
+        JobsGet.getJobs("partition", "", null, 0, 0, "JOB_ID:ASCENDING");
+        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
+            "partition", "", null, 0, 0, JobSortField.JOB_ID, SortDirection.ASCENDING);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testGetJobs_Failure_InvalidSort() throws Exception {
+        JobsGet.getJobs("partition", "", null, 0, 0, "invalid");
     }
 
     @Test(expected = BadRequestException.class)
     public void testGetJobs_Failure_InvalidSortField() throws Exception {
-        JobsGet.getJobs("partition", "", null, 0, 0, "unknown", null);
-    }
-
-    public void testGetJobs_Success_WithSortField() throws Exception {
-        JobsGet.getJobs("partition", "", null, 0, 0, "JOB_ID", null);
-        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
-            "partition", "", null, 0, 0, JobSortField.JOB_ID, JobSortOrder.ASCENDING);
+        JobsGet.getJobs("partition", "", null, 0, 0, "UNKNOWN:DESCENDING");
     }
 
     @Test(expected = BadRequestException.class)
-    public void testGetJobs_Failure_InvalidSortOrder() throws Exception {
-        JobsGet.getJobs("partition", "", null, 0, 0, null, "random");
-    }
-
-    public void testGetJobs_Success_WithSortOrder() throws Exception {
-        JobsGet.getJobs("partition", "", null, 0, 0, null, "ASCENDING");
-        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
-            "partition", "", null, 0, 0, JobSortField.CREATE_DATE, JobSortOrder.ASCENDING);
-    }
-
-    public void testGetJobs_Success_WithSortFieldAndSortOrder() throws Exception {
-        JobsGet.getJobs("partition", "", null, 0, 0, "JOB_ID", "DESCENDING");
-        Mockito.verify(mockDatabaseHelper, Mockito.times(1)).getJobs(
-            "partition", "", null, 0, 0, JobSortField.JOB_ID, JobSortOrder.DESCENDING);
+    public void testGetJobs_Failure_InvalidSortDirection() throws Exception {
+        JobsGet.getJobs("partition", "", null, 0, 0, "JOB_ID:RANDOM");
     }
 
 }

--- a/release-notes-3.1.0.md
+++ b/release-notes-3.1.0.md
@@ -9,7 +9,7 @@ ${version-number}
        Job types can be defined, and new jobs can target a type to use a well-defined, type-specific input format.
 - [SCMOD-7309](https://portal.digitalsafe.net/browse/SCMOD-7309) NotFinished job status filter  
         The statusType parameter accepts a new value, which includes only jobs which haven't reached a final state.
-- [SCMOD-7308](https://portal.digitalsafe.net/browse/SCMOD-7308) Job list sort options  
-        The sortField and sortOrder parameters have been added to the jobsGet API.
+- [SCMOD-7308](https://portal.digitalsafe.net/browse/SCMOD-7308) Job list sorting  
+        The sort parameter has been added to the jobsGet API.
 
 #### Known Issues

--- a/release-notes-3.1.0.md
+++ b/release-notes-3.1.0.md
@@ -9,5 +9,7 @@ ${version-number}
        Job types can be defined, and new jobs can target a type to use a well-defined, type-specific input format.
 - [SCMOD-7309](https://portal.digitalsafe.net/browse/SCMOD-7309) NotFinished job status filter  
         The statusType parameter accepts a new value, which includes only jobs which haven't reached a final state.
+- [SCMOD-7308](https://portal.digitalsafe.net/browse/SCMOD-7308) Job list sort options  
+        The sortField and sortOrder parameters have been added to the jobsGet API.
 
 #### Known Issues


### PR DESCRIPTION
I've only included job ID (needed for classifications) and create date (the previous default) columns.

The default order is a bit weird: descending if no column is given (for backwards compatibility), ascending otherwise (I thought descending would be a strange general default).  An alternative would be to have the default order depend on the column (ascending for job ID, descending for create date).

- ticket: https://portal.digitalsafe.net/browse/SCMOD-7308
- build: http://sou-jenkins2.hpeswlab.net/job/JobService/job/JobService~job-service~SCMOD-7308~CI/