### PR TITLE
SCMOD-8513: Fix schema pattern and deprecate external data field

### DIFF
--- a/docs/pages/en-us/Getting-Started.md
+++ b/docs/pages/en-us/Getting-Started.md
@@ -43,13 +43,14 @@ Adjust 'docker-host' to be the name of your own Docker Host and adjust the port 
  
 	* `name`: name of the job. <br>
 	* `description`: description of the job. <br>
-	* `externalData`: external data (i.e. information that you want associated with the job but that has no effect on it). <br>
+	* `externalData`: Deprecated in 3.2.0, replaced by `labels` - external data (i.e. information that you want associated with the job but that has no effect on it). <br>
 	* `taskClassifier`: specifies the type of message being sent. Worker feeding off `taskPipe` queue should be able to process this message. <br>
 	* `taskApiVersion`: API version of the task. <br>
 	* `taskData`: data of the task to be sent. This can be presented in a string format or in a more readable and friendly object format. <br>
 	* `taskDataEncoding`: encoding of the `taskData` field value e.g. `utf8`. Only required if `taskData` field is specified in string format. <br>
 	* `taskPipe`: name of the RabbitMQ queue feeding messages to the first worker. <br>
-	* `targetPipe`: name of the final worker's RabbitMQ output queue where tracking will stop. <br><br>
+	* `targetPipe`: name of the final worker's RabbitMQ output queue where tracking will stop. <br>
+	* `labels`: A map of meta data associated with this job. Note that the keys can only include alphanumeric, '_', '-' and ':' characters <br><br>
 
 6. Press `Try it out!`. The resulting code will show whether the addition of the job succeeds or not. 
    - 201, if the job is successfully added

--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -280,8 +280,7 @@ definitions:
         #       would mean xpath searches could be done later
         type: string
         description: |
-          External data can be associated with the job for use by other
-          components.
+          DEPRECATED - Replaced by labels
       task:
         $ref: "#/definitions/worker-action"
       type:
@@ -304,9 +303,8 @@ definitions:
         type: object
         additionalProperties:
           type: string
-          pattern: '^(?!\s*$)[a-zA-Z0-9_\- :]+$'
           minLength: 1
-        description: A map of meta data associated with this job.
+        description: A map of meta data associated with this job. Note that the keys must match the following regex ^(?!\s*$)[a-zA-Z0-9_\- :]+$
         example:
           "tag:4": "4"
           owner: "bob"
@@ -350,8 +348,7 @@ definitions:
       externalData:
         type: string
         description: |
-          External data can be associated with the job for use by other
-          components.
+          DEPRECATED - Replaced by labels
       createTime:
         type: string
         format: date-time
@@ -383,9 +380,8 @@ definitions:
         type: object
         additionalProperties:
           type: string
-          pattern: '^(?!\s*$)[a-zA-Z0-9_\- :]+$'
           minLength: 1
-        description: A map of meta data associated with this job.
+        description: A map of meta data associated with this job. Note that the keys must match the following regex ^(?!\s*$)[a-zA-Z0-9_\- :]+$
   failure:
     type: object
     properties:

--- a/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
+++ b/job-service-contract/src/main/resources/com/hpe/caf/services/job/swagger.yaml
@@ -280,7 +280,8 @@ definitions:
         #       would mean xpath searches could be done later
         type: string
         description: |
-          DEPRECATED - Replaced by labels
+          DEPRECATED - Replaced by labels. External data can be associated with the job for use by other
+          components.
       task:
         $ref: "#/definitions/worker-action"
       type:
@@ -303,8 +304,9 @@ definitions:
         type: object
         additionalProperties:
           type: string
-          minLength: 1
-        description: A map of meta data associated with this job. Note that the keys must match the following regex ^(?!\s*$)[a-zA-Z0-9_\- :]+$
+        description: |
+          A map of meta data associated with this job. Note that the keys can only include alphanumeric, '_', '-' and
+          ':' characters
         example:
           "tag:4": "4"
           owner: "bob"
@@ -348,7 +350,8 @@ definitions:
       externalData:
         type: string
         description: |
-          DEPRECATED - Replaced by labels
+          DEPRECATED - Replaced by labels External data can be associated with the job for use by other
+          components.
       createTime:
         type: string
         format: date-time
@@ -380,8 +383,9 @@ definitions:
         type: object
         additionalProperties:
           type: string
-          minLength: 1
-        description: A map of meta data associated with this job. Note that the keys must match the following regex ^(?!\s*$)[a-zA-Z0-9_\- :]+$
+        description: |
+          A map of meta data associated with this job. Note that the keys can only include alphanumeric, '_', '-' and
+          ':' characters
   failure:
     type: object
     properties:

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
@@ -129,7 +129,7 @@ public final class JobsPut {
             }
 
             // Make sure label names are valid.
-            if (job.getLabels() != null && !job.getLabels().isEmpty() &&
+            if (job.getLabels() != null &&
                     job.getLabels().keySet().stream().anyMatch(key -> !LABEL_PATTERN.matcher(key).matches())) {
                 LOG.error("createOrUpdateJob: Error - '{}'", ERR_MSG_INVALID_LABEL_NAME);
                 throw new BadRequestException(ERR_MSG_INVALID_LABEL_NAME);

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/JobsPut.java
@@ -129,11 +129,10 @@ public final class JobsPut {
             }
 
             // Make sure label names are valid.
-            if(job.getLabels() != null && !job.getLabels().isEmpty()) {
-                if (job.getLabels().keySet().stream().anyMatch(key -> !LABEL_PATTERN.matcher(key).matches())) {
-                    LOG.error("createOrUpdateJob: Error - '{}'", ERR_MSG_INVALID_LABEL_NAME);
-                    throw new BadRequestException(ERR_MSG_INVALID_LABEL_NAME);
-                }
+            if (job.getLabels() != null && !job.getLabels().isEmpty() &&
+                    job.getLabels().keySet().stream().anyMatch(key -> !LABEL_PATTERN.matcher(key).matches())) {
+                LOG.error("createOrUpdateJob: Error - '{}'", ERR_MSG_INVALID_LABEL_NAME);
+                throw new BadRequestException(ERR_MSG_INVALID_LABEL_NAME);
             }
             
             final Object taskData = jobTask.getTaskData();

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/Job.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/Job.java
@@ -34,6 +34,10 @@ public class Job   {
     private String id = null;
     private String name = null;
     private String description = null;
+    /**
+     * @deprecated 21/01/2020 - Replaced by labels functionality.
+     */
+    @Deprecated
     private String externalData = null;
     private Date createTime = null;
     private Date lastUpdateTime = null;

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/NewJob.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/NewJob.java
@@ -35,6 +35,10 @@ public class NewJob   {
 
     private String name = null;
     private String description = null;
+    /**
+     * @deprecated 21/01/2020 - Replaced by labels functionality.
+     */
+    @Deprecated
     private String externalData = null;
     private WorkerAction task = null;
     private String type = null;

--- a/release-notes-3.2.0.md
+++ b/release-notes-3.2.0.md
@@ -5,4 +5,8 @@ ${version-number}
 
 #### New Features
 
+* **SCMOD-8513**: Labels<br>
+Extra key-value pair metadata can be associated with new jobs. 
+Replaces externalData field which has been deprecated.
+
 #### Known Issues


### PR DESCRIPTION
Note - swagger 2.0 doesn't support `propertyNames` or `deprecated` keywords so descriptions have been updated.