### PR TITLE
SCMOD-9665: Upgrade Util liquibase version using postgresql driver version 42.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
             <dependency>
                 <groupId>com.github.cafapi.util</groupId>
                 <artifactId>util-liquibase-installer</artifactId>
-                <version>1.17.0-201</version>
+                <version>1.18.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.jobservice</groupId>


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-9665