### PR TITLE
SCMOD-9913: Change JSLT filter to default implmentation

### DIFF
--- a/job-service/src/main/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilder.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilder.java
@@ -21,11 +21,13 @@ import com.hpe.caf.services.job.exceptions.BadRequestException;
 import com.schibsted.spt.data.jslt.Expression;
 import com.schibsted.spt.data.jslt.JsltException;
 import com.schibsted.spt.data.jslt.Parser;
-import com.schibsted.spt.data.jslt.filters.TrueJsonFilter;
+import com.schibsted.spt.data.jslt.filters.DefaultJsonFilter;
 
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Constructs task data using a JSLT script.  See the `Job-Types.md` document for a specification.
@@ -33,6 +35,8 @@ import java.util.Map;
  * @see com.schibsted.spt.data.jslt
  */
 final class JsltTaskDataBuilder implements TaskDataBuilder {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(JsltTaskDataBuilder.class);
     /**
      * Used for building script input.
      */
@@ -72,11 +76,11 @@ final class JsltTaskDataBuilder implements TaskDataBuilder {
         this.targetPipe = targetPipe;
         this.configuration = configuration;
         this.parametersValidator = parametersValidator;
-
+        
         try {
             script = new Parser(new StringReader(taskDataScript))
                 .withSource(jobTypeId)
-                .withObjectFilter(new TrueJsonFilter())
+                .withObjectFilter(new DefaultJsonFilter())
                 .compile();
         } catch (final JsltException e) {
             throw new InvalidJobTypeDefinitionException(

--- a/job-service/src/main/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilder.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilder.java
@@ -33,7 +33,6 @@ import java.util.Map;
  * @see com.schibsted.spt.data.jslt
  */
 final class JsltTaskDataBuilder implements TaskDataBuilder {
-
     /**
      * Used for building script input.
      */

--- a/job-service/src/main/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilder.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilder.java
@@ -26,8 +26,6 @@ import com.schibsted.spt.data.jslt.filters.DefaultJsonFilter;
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Constructs task data using a JSLT script.  See the `Job-Types.md` document for a specification.
@@ -35,8 +33,7 @@ import org.slf4j.LoggerFactory;
  * @see com.schibsted.spt.data.jslt
  */
 final class JsltTaskDataBuilder implements TaskDataBuilder {
-    
-    private static final Logger LOG = LoggerFactory.getLogger(JsltTaskDataBuilder.class);
+
     /**
      * Used for building script input.
      */
@@ -76,7 +73,7 @@ final class JsltTaskDataBuilder implements TaskDataBuilder {
         this.targetPipe = targetPipe;
         this.configuration = configuration;
         this.parametersValidator = parametersValidator;
-        
+
         try {
             script = new Parser(new StringReader(taskDataScript))
                 .withSource(jobTypeId)

--- a/job-service/src/test/java/com/hpe/caf/services/job/jobtype/DefaultDefinitionParserTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/jobtype/DefaultDefinitionParserTest.java
@@ -91,8 +91,7 @@ public class DefaultDefinitionParserTest {
 
         final Map<String, Map<String, String>> taskData = JobTypeTestUtil.objectMapper.convertValue(
             task.getTaskData(), new TypeReference<Map<String, Map<String, String>>>() {});
-        Assert.assertEquals("should fill in empty configuration",
-            Collections.EMPTY_MAP, taskData.get("cfg"));
+        Assert.assertNull("should not fill in empty configuration", taskData.get("cfg"));
 
         // should fill in params schema that expects null
         expectedException.expect(BadRequestException.class);

--- a/job-service/src/test/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilderTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilderTest.java
@@ -35,7 +35,7 @@ public class JsltTaskDataBuilderTest {
         final TaskDataBuilder builder = new JsltTaskDataBuilder(
             "type", "task pipe", "target pipe", config, paramValidatorSuccess, ".");
         final JsonNode actualTaskData =
-            builder.build(null, "job id", TextNode.valueOf("params"));
+            builder.build("partition id", "job id", TextNode.valueOf("params"));
 
         final Map<String, Object> expectedTaskData = new HashMap<>();
         expectedTaskData.put("configuration", config);

--- a/job-service/src/test/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilderTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/jobtype/JsltTaskDataBuilderTest.java
@@ -35,7 +35,7 @@ public class JsltTaskDataBuilderTest {
         final TaskDataBuilder builder = new JsltTaskDataBuilder(
             "type", "task pipe", "target pipe", config, paramValidatorSuccess, ".");
         final JsonNode actualTaskData =
-            builder.build("partition id", "job id", TextNode.valueOf("params"));
+            builder.build(null, "job id", TextNode.valueOf("params"));
 
         final Map<String, Object> expectedTaskData = new HashMap<>();
         expectedTaskData.put("configuration", config);
@@ -103,9 +103,7 @@ public class JsltTaskDataBuilderTest {
         final JsonNode actualTaskData =
             builder.build("partition id", "job id", TextNode.valueOf("params"));
 
-        final Map<String, Object> expectedTaskData = new HashMap<>();
-        expectedTaskData.put("empty", Collections.emptyMap());
-        Assert.assertEquals(JobTypeTestUtil.convertJson(expectedTaskData), actualTaskData);
+        Assert.assertEquals(JobTypeTestUtil.convertJson(Collections.emptyMap()), actualTaskData);
     }
 
 }

--- a/release-notes-3.3.0.md
+++ b/release-notes-3.3.0.md
@@ -5,4 +5,8 @@ ${version-number}
 - SCMOD-8484: Propagate failures through subtasks  
 Functionality has been added that allows for the failure of a task to propagate up through any tasks that are no longer able to run because the task has failed.  
 
+#### Bug Fixes
+- SCMOD-9913: The JSLT parser used for parsing the [taskDataScript](https://github.com/JobService/job-service/blob/develop/docs/pages/en-us/Job-Types.md#taskdatascript)
+has been changed so that JSON properties are excluded from the output if the property value is null, an empty array, or an empty object.
+
 #### Known Issues


### PR DESCRIPTION
The [taskDataScript ](https://github.com/JobService/job-service/blob/develop/docs/pages/en-us/Job-Types.md#taskdatascript) JSLT parsing code was previously using the `TrueJsonFilter`, which means that all JSON values, including null, empty arrays, and empty objects were included in the JSLT output.

I've changed this to use the `DefaultJSONFilter` instead, which will exclude any JSON properties from the output if their value is null, an empty array, or an empty object.