### PR TITLE
SCMOD-10183: Updated database procedure params

### DIFF
--- a/job-service-container/README.md
+++ b/job-service-container/README.md
@@ -17,4 +17,18 @@ This docker image contains the [Job Service](../job-service) hosted in Apache To
 [Architecture](https://jobservice.github.io/job-service/pages/en-us/Architecture)
 
 ## Feature Testing
-The testing for Job Service is defined [here](../testcases)
+The testing for Job Service is defined [here](../testcases)  
+
+### Configuration  
+
+- `CAF_JOB_SERVICE_PROPAGATE_FAILURES`  
+`description`: This environment variable will indicate if the service should propagate job failures through subtasks. This means that if a task fails and as a result other tasks are not able to be run due to prerequisite commitments, those other tasks will be marked as failures also.
+For instance, in the example below all tasks will be marked as failures because T1 failed. Possible values are `true` and `false`.  
+`default`: false  
+`example`: T1 has two dependent tasks, T2 and T3, T3 also has a dependent task T4. If this environment variable is set to true then the failure of T1 will cause the marking of tasks T2, T3 and T4 as failed as none of them will ever be eligible to run.  
+````
+T1
+ |->T2
+ |->T3
+     |->T4
+````

--- a/job-service-scheduled-executor/README.md
+++ b/job-service-scheduled-executor/README.md
@@ -6,4 +6,18 @@ The Job Service Scheduled Executor is a polling service that identifies jobs in 
 The Job Service has the ability to execute jobs in an order defined by a job having a dependency on another job.  The Job Service will not execute a job until all the jobs it is dependent upon have completed.  The job can be configured to wait for a specified length of time after all the jobs it is dependent upon have completed before it is executed. 
 
 ### ExecutorService
-The Job Service Scheduled Executor is an ExecutorService which schedules a task to execute repeatedly identifying jobs which are now ready to run. For each job identified, a message is published on to RabbitMQ to start the job.
+The Job Service Scheduled Executor is an ExecutorService which schedules a task to execute repeatedly identifying jobs which are now ready to run. For each job identified, a message is published on to RabbitMQ to start the job.  
+
+### Configuration  
+
+- `CAF_JOB_SCHEDULAR_PROPAGATE_FAILURES`  
+`description`: This environment variable will indicate if the service should propagate job failures through subtasks. This means that if a task fails and as a result other tasks are not able to be run due to prerequisite commitments, those other tasks will be marked as failures also.
+For instance, in the example below all tasks will be marked as failures because T1 failed. Possible values are `true` and `false`.  
+`default`: false  
+`example`: T1 has two dependent tasks, T2 and T3, T3 also has a dependent task T4. If this environment variable is set to true then the failure of T1 will cause the marking of tasks T2, T3 and T4 as failed as none of them will ever be eligible to run.  
+````
+T1
+ |->T2
+ |->T3
+     |->T4
+````

--- a/job-service-scheduled-executor/src/main/java/com/hpe/caf/services/job/scheduled/executor/DatabasePoller.java
+++ b/job-service-scheduled-executor/src/main/java/com/hpe/caf/services/job/scheduled/executor/DatabasePoller.java
@@ -50,7 +50,7 @@ public class DatabasePoller
     private static final boolean PROP_DEPENDENT_JOB_FAILURES;
 
     static {
-        final String propDepJoFailures = System.getenv("CAF_JOB_TRACKING_PROPAGATE_FAILURES");
+        final String propDepJoFailures = System.getenv("CAF_JOB_SCHEDULAR_PROPAGATE_FAILURES");
         PROP_DEPENDENT_JOB_FAILURES = propDepJoFailures != null ? Boolean.parseBoolean(propDepJoFailures) : false;
     }
 

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
@@ -51,6 +51,8 @@ public final class DatabaseHelper
 
     private static final Logger LOG = LoggerFactory.getLogger(DatabaseHelper.class);
 
+    public final boolean propagateDependentJobFailures;
+
     /**
      * Instantiates a new DBUtil
      *
@@ -59,6 +61,8 @@ public final class DatabaseHelper
     public DatabaseHelper(AppConfig appConfig)
     {
         DatabaseHelper.appConfig = appConfig;
+        final String propDepJoFailures = System.getenv("CAF_JOB_TRACKING_PROPAGATE_FAILURES");
+        propagateDependentJobFailures = propDepJoFailures != null ? Boolean.parseBoolean(propDepJoFailures) : false;
     }
 
     public Job[] getJobs(final String partitionId, String jobIdStartsWith, String statusType, Integer limit,
@@ -487,11 +491,12 @@ public final class DatabaseHelper
 
         try (
                 Connection conn = DatabaseConnectionProvider.getConnection(appConfig);
-                CallableStatement stmt = conn.prepareCall("{call report_failure(?,?,?)}")
+                CallableStatement stmt = conn.prepareCall("{call report_failure(?,?,?,?)}")
         ) {
             stmt.setString(1, partitionId);
             stmt.setString(2,jobId);
             stmt.setString(3,failureDetails);
+            stmt.setBoolean(4, propagateDependentJobFailures);
 
             LOG.debug("Calling report_failure() database function...");
             stmt.execute();

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
@@ -61,7 +61,7 @@ public final class DatabaseHelper
     public DatabaseHelper(AppConfig appConfig)
     {
         DatabaseHelper.appConfig = appConfig;
-        final String propDepJoFailures = System.getenv("CAF_JOB_TRACKING_PROPAGATE_FAILURES");
+        final String propDepJoFailures = System.getenv("CAF_JOB_SERVICE_PROPAGATE_FAILURES");
         propagateDependentJobFailures = propDepJoFailures != null ? Boolean.parseBoolean(propDepJoFailures) : false;
     }
 


### PR DESCRIPTION
Example Failed Job: 
````
[
  {
    "lastUpdateTime": 1595939777401,
    "id": "job1",
    "name": "Ingest documents submitted in batches A and B",
    "description": "This job ingests all of the documents that were in the A and B batches.",
    "externalData": null,
    "createTime": 1595939777247,
    "status": "Failed",
    "percentageComplete": 0,
    "failures": [
      {
        "failureId": "ADD_TO_QUEUE_FAILURE",
        "failureTime": 1595939777376,
        "failureSource": "Job Service - PUT /partitions/{tenant-anthonymcg}/jobs/{job1}",
        "failureMessage": "ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile."
      }
    ]
  }
]
````