### PR TITLE
SCMOD-9552: Updated to reuse failure source

### DIFF
--- a/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
@@ -514,7 +514,7 @@ public final class DatabaseHelper
                 final Failure f;
                 if (jFailure.has("root_failure")) {
                     f = getFailureFromJsonObject(new JSONObject(jFailure.getString("failure_details")));
-                    f.setFailureSource(jFailure.getString("root_failure"));
+                    f.setFailureSource(jFailure.getString("root_failure") + ":" + f.getFailureSource());
                 } else {
                     f = getFailureFromJsonObject(jFailure);
                 }

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/DatabaseHelper.java
@@ -514,7 +514,7 @@ public final class DatabaseHelper
                 final Failure f;
                 if (jFailure.has("root_failure")) {
                     f = getFailureFromJsonObject(new JSONObject(jFailure.getString("failure_details")));
-                    f.setRootFailure(jFailure.getString("root_failure"));
+                    f.setFailureSource(jFailure.getString("root_failure"));
                 } else {
                     f = getFailureFromJsonObject(jFailure);
                 }

--- a/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/Failure.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/api/generated/model/Failure.java
@@ -15,8 +15,6 @@
  */
 package com.hpe.caf.services.job.api.generated.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -32,9 +30,6 @@ public class Failure   {
     private Date failureTime = null;
     private String failureSource = null;
     private String failureMessage = null;
-
-    @JsonInclude(Include.NON_NULL)
-    private String rootFailure = null;
 
     /**
      **/
@@ -105,16 +100,6 @@ public class Failure   {
         this.failureMessage = failureMessage;
     }
 
-    @ApiModelProperty(value = "")
-    @JsonProperty("rootFailure")
-    public String getRootFailure() {
-        return rootFailure;
-    }
-    public void setRootFailure(final String rootFailure) {
-        this.rootFailure = rootFailure;
-    }
-
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -127,13 +112,12 @@ public class Failure   {
         return Objects.equals(failureId, failure.failureId) &&
                 Objects.equals(failureSource, failure.failureSource) &&
                 Objects.equals(failureTime, failure.failureTime) &&
-                Objects.equals(rootFailure, failure.rootFailure) &&
                 Objects.equals(failureMessage, failure.failureMessage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(failureId, failureTime, failureSource, failureMessage, rootFailure);
+        return Objects.hash(failureId, failureTime, failureSource, failureMessage);
     }
 
     @Override
@@ -141,7 +125,6 @@ public class Failure   {
         StringBuilder sb = new StringBuilder();
         sb.append("class Failure {\n");
 
-        sb.append("    rootFailure: ").append(toIndentedString(rootFailure)).append("\n");
         sb.append("    failureId: ").append(toIndentedString(failureId)).append("\n");
         sb.append("    failureSource: ").append(toIndentedString(failureSource)).append("\n");
         sb.append("    failureTime: ").append(toIndentedString(failureTime)).append("\n");


### PR DESCRIPTION
Failure source now used to represent rootFailure of a dependent job.
Example Output:
````
[
  {
    "lastUpdateTime": 1595943088212,
    "id": "job2",
    "name": "Ingest documents submitted in batches A and B",
    "description": "This job ingests all of the documents that were in the A and B batches.",
    "externalData": null,
    "createTime": 1595943056737,
    "status": "Failed",
    "percentageComplete": 0,
    "failures": [
      {
        "failureId": "RESULT_EXCEPTION",
        "failureTime": 1587477232847,
        "failureSource": "tenant-anthonymcg:job1",
        "failureMessage": "EW-0005: Operation failed: {\"type\":\"strict_dynamic_mapping_exception\",\"reason\":\"mapping set to strict, dynamic introduction of [OTHER_DATA] within [HOLDS.CUSTOM_DATA] is not allowed\"}"
      }
    ]
  },
  {
    "lastUpdateTime": 1595943088212,
    "id": "job1",
    "name": "Ingest documents submitted in batches A and B",
    "description": "This job ingests all of the documents that were in the A and B batches.",
    "externalData": null,
    "createTime": 1595943052317,
    "status": "Failed",
    "percentageComplete": 0,
    "failures": [
      {
        "failureId": "RESULT_EXCEPTION",
        "failureTime": 1587477232847,
        "failureSource": "worker-elastic",
        "failureMessage": "EW-0005: Operation failed: {\"type\":\"strict_dynamic_mapping_exception\",\"reason\":\"mapping set to strict, dynamic introduction of [OTHER_DATA] within [HOLDS.CUSTOM_DATA] is not allowed\"}"
      }
    ]
  }
]
````