### PR TITLE
SCMOD-11755: Explicitly specify base image

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -82,7 +82,9 @@
                             <alias>source-code</alias>
                             <name>${project.artifactId}-source-code:${project.version}</name>
                             <build>
+                                <from>${dockerHubPublic}/library/busybox:latest</from>
                                 <assembly>
+                                    <exportTargetDir>true</exportTargetDir>
                                     <targetDir>/data</targetDir>
                                     <inline xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                                             xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-11755

This change really should have been made as part of the [SCMOD-5156](https://portal.digitalsafe.net/browse/SCMOD-5156) changes.  Clearly cases where no base image was specified and the docker-maven-plugin defaulted to `busybox:latest` were overlooked.