### PR TITLE
Further optimization of tests

### DIFF
--- a/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
+++ b/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
@@ -47,6 +47,8 @@ import java.util.*;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertThrows;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Integration tests for Job Tracking Worker.
@@ -67,6 +69,8 @@ public class JobTrackingWorkerIT {
     private static JobDatabase jobDatabase;
 
     private String defaultPartitionId;
+    
+    private static final Logger LOG = LoggerFactory.getLogger(JobTrackingWorkerIT.class);
 
 
     @BeforeClass
@@ -192,8 +196,17 @@ public class JobTrackingWorkerIT {
             final JobDatabase database = new JobDatabase();
             // Increased the waiting time to match the 10s to wait induced by the batch
             // (see in JobtrackingWorkerFactory.processTasks())
-            wait(2000);
-            database.verifyJobStatus(defaultPartitionId, jobTaskId, expectation);
+            //wait(2000);
+            for (int i = 0; i < 20; i++) {
+                try {
+                    database.verifyJobStatus(defaultPartitionId, jobTaskId, expectation);
+                    LOG.info("Job status: true");
+                }
+                catch (Exception exception){
+                    Thread.sleep(100);
+                    LOG.info("sleep");
+                }
+            }
         }
     }
 

--- a/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
+++ b/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
@@ -47,8 +47,6 @@ import java.util.*;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertThrows;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Integration tests for Job Tracking Worker.
@@ -69,9 +67,6 @@ public class JobTrackingWorkerIT {
     private static JobDatabase jobDatabase;
 
     private String defaultPartitionId;
-    
-    private static final Logger LOG = LoggerFactory.getLogger(JobTrackingWorkerIT.class);
-
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
+++ b/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
@@ -68,6 +68,7 @@ public class JobTrackingWorkerIT {
 
     private String defaultPartitionId;
 
+    
     @BeforeClass
     public static void setup() throws Exception {
         BootstrapConfiguration bootstrap = new SystemBootstrapConfiguration();

--- a/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
+++ b/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
@@ -194,17 +194,12 @@ public class JobTrackingWorkerIT {
                         defaultPartitionId, jobTaskId, jobTaskId, true, expectation)));
             queueManager.publish(taskMessage);
             final JobDatabase database = new JobDatabase();
-            // Increased the waiting time to match the 10s to wait induced by the batch
-            // (see in JobtrackingWorkerFactory.processTasks())
-            //wait(2000);
             for (int i = 0; i < 20; i++) {
                 try {
                     database.verifyJobStatus(defaultPartitionId, jobTaskId, expectation);
-                    LOG.info("Job status: true");
                 }
                 catch (Exception exception){
                     Thread.sleep(100);
-                    LOG.info("sleep");
                 }
             }
         }

--- a/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
+++ b/worker-jobtracking-container/src/test/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerIT.java
@@ -68,7 +68,7 @@ public class JobTrackingWorkerIT {
 
     private String defaultPartitionId;
 
-    
+
     @BeforeClass
     public static void setup() throws Exception {
         BootstrapConfiguration bootstrap = new SystemBootstrapConfiguration();


### PR DESCRIPTION
@dermot-hardy  I found this hard coded wait in the job tracking worker tests so added this to only wait until the verifyJobStatus returns without exception. Not sure if this is ok or not but it seems to take some time off the build.