### PR TITLE
SCMOD-11252: Replace use of ProcessEnvironment class

### DIFF
--- a/job-service-admin/pom.xml
+++ b/job-service-admin/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
                 <version>3.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-rules</artifactId>
+                <version>1.19.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-example-shared</artifactId>
                 <version>1.8.0-249</version>


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-11252

Using the `ProcessEnvironment `class to set environment variables in unit tests does not work sometimes, due to the class returning different fields in different versions of Java:

https://stackoverflow.com/a/62855645/12177456

We can work around it using something like this:

https://github.houston.softwaregrp.net/caf/caf-storage/pull/274/files#diff-6eb71c520c088c4c17059d20c5fa3a94R50

but using a JUnit rule here seems to be a little simpler.