### PR TITLE
SCMOD-11252: Use cafapi/opensuse-jdk8-maven:1.0.0 build image

### DIFF
--- a/official-build.props
+++ b/official-build.props
@@ -1,2 +1,3 @@
 DISABLE_AUTOTAGGING=true
 USE_OPEN_SOURCE_SETTINGS=false
+SEPG_BUILD_ENV_IMAGE=cafapi/opensuse-jdk8-maven:1.0.0


### PR DESCRIPTION
Jira: https://portal.digitalsafe.net/browse/SCMOD-11252 