### PR TITLE
SCMOD-12505: Make job type config more flexible

### DIFF
--- a/docs/pages/en-us/Job-Types.md
+++ b/docs/pages/en-us/Job-Types.md
@@ -19,9 +19,9 @@ Job Service can be configured with job types by including a number of job type d
 
 To configure Job Service with job types, define the environment variable `CAF_JOB_SERVICE_JOB_TYPE_DEFINITIONS_DIR`.  This is the path to a directory containing job type definition files with the '.yaml' extension.  The filename, excluding the '.yaml' extension, is used as a unique identifier for the job type.  Changes to these files do not take effect until Job Service is restarted.
 
-A job type definition may specify additional properties (see `configurationProperties` below).  To configure these values, define environment variables using the job type ID (specified in the job type definition) and the property name.  For example, a job type with ID `standard_ingest`, defining the additional property `storeName`, must have the following environment variables defined:
+A job type definition may specify additional properties (see `configurationProperties` below). To configure these values, define environment variables for them.  For example, to define the additional property `storeName`, this environment variable must be defined:
  
- - `CAF_JOB_SERVICE_JOB_TYPE_STANDARD_INGEST_STORENAME`
+ - `STORENAME`
 
 ## Defining a Job Type
 

--- a/job-service-config/src/main/java/com/hpe/caf/services/configuration/AppConfig.java
+++ b/job-service-config/src/main/java/com/hpe/caf/services/configuration/AppConfig.java
@@ -102,15 +102,13 @@ public class AppConfig {
     }
 
     /**
-     * Retrieve a configuration property specific to a job type.
+     * Retrieve a configuration property.
      *
-     * @param jobTypeId
      * @param propertyName
      * @return Property value, possibly `null`
      */
-    public String getJobTypeProperty(final String jobTypeId, final String propertyName) {
-        return environment.getProperty("CAF_JOB_SERVICE_JOB_TYPE_" +
-            jobTypeId.toUpperCase(Locale.ENGLISH) + "_" + propertyName.toUpperCase(Locale.ENGLISH));
+    public String getJobProperty(final String propertyName) {
+        return environment.getProperty(propertyName.toUpperCase(Locale.ENGLISH));
     }
 
     public Pattern getSuspendedPartitionsPattern() {

--- a/job-service-container/pom.xml
+++ b/job-service-container/pom.xml
@@ -494,22 +494,22 @@
                                     <SSL_TOMCAT_CA_CERT_LOCATION>/test-keystore/tomcat.keystore</SSL_TOMCAT_CA_CERT_LOCATION>
                                     <CAF_JOB_SERVICE_JOB_TYPE_DEFINITIONS_DIR>/test-job-type-definitions</CAF_JOB_SERVICE_JOB_TYPE_DEFINITIONS_DIR>
 
-                                    <JOB_TYPE_BASIC_TASK_PIPE>basic task-pipe</JOB_TYPE_BASIC_TASK_PIPE>
-                                    <JOB_TYPE_BASIC_TARGET_PIPE>basic target-pipe</JOB_TYPE_BASIC_TARGET_PIPE>
-                                    <JOB_TYPE_CONFIG_TASK_PIPE>config task-pipe</JOB_TYPE_CONFIG_TASK_PIPE>
-                                    <JOB_TYPE_CONFIG_TARGET_PIPE>config target-pipe</JOB_TYPE_CONFIG_TARGET_PIPE>
-                                    <JOB_TYPE_CONFIG_UPPER>upper value</JOB_TYPE_CONFIG_UPPER>
-                                    <JOB_TYPE_CONFIG_LOWER>lower value</JOB_TYPE_CONFIG_LOWER>
-                                    <JOB_TYPE_CONFIG_MULTIPLE>multiple value</JOB_TYPE_CONFIG_MULTIPLE>
-                                    <JOB_TYPE_CONFIG_NODESC>nodesc value</JOB_TYPE_CONFIG_NODESC>
-                                    <JOB_TYPE_CONFIG_NUMBER>123</JOB_TYPE_CONFIG_NUMBER>
-                                    <JOB_TYPE_PARAMS_TASK_PIPE>params task-pipe</JOB_TYPE_PARAMS_TASK_PIPE>
-                                    <JOB_TYPE_PARAMS_TARGET_PIPE>params target-pipe</JOB_TYPE_PARAMS_TARGET_PIPE>
-                                    <JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE>complex task-pipe</JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE>
-                                    <JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE>complex target-pipe</JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE>
-                                    <JOB_TYPE_INVALID-OUTPUT_TASK_PIPE>invalid-output task-pipe</JOB_TYPE_INVALID-OUTPUT_TASK_PIPE>
-                                    <JOB_TYPE_INVALID-OUTPUT_TARGET_PIPE>invalid-output target-pipe</JOB_TYPE_INVALID-OUTPUT_TARGET_PIPE>
-                                    <JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE>null-target-pipe task-pipe</JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_BASIC_TASK_PIPE>basic task-pipe</CAF_JOB_SERVICE_JOB_TYPE_BASIC_TASK_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_BASIC_TARGET_PIPE>basic target-pipe</CAF_JOB_SERVICE_JOB_TYPE_BASIC_TARGET_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TASK_PIPE>config task-pipe</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TASK_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TARGET_PIPE>config target-pipe</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TARGET_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_UPPER>upper value</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_UPPER>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_LOWER>lower value</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_LOWER>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_MULTIPLE>multiple value</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_MULTIPLE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_NODESC>nodesc value</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_NODESC>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_NUMBER>123</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_NUMBER>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TASK_PIPE>params task-pipe</CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TASK_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TARGET_PIPE>params target-pipe</CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TARGET_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE>complex task-pipe</CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE>complex target-pipe</CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_INVALID-OUTPUT_TASK_PIPE>invalid-output task-pipe</CAF_JOB_SERVICE_JOB_TYPE_INVALID-OUTPUT_TASK_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_INVALID-OUTPUT_TARGET_PIPE>invalid-output target-pipe</CAF_JOB_SERVICE_JOB_TYPE_INVALID-OUTPUT_TARGET_PIPE>
+                                    <CAF_JOB_SERVICE_JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE>null-target-pipe task-pipe</CAF_JOB_SERVICE_JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE>
                                 </env>
                                 <volumes>
                                     <from>

--- a/job-service-container/pom.xml
+++ b/job-service-container/pom.xml
@@ -494,23 +494,22 @@
                                     <SSL_TOMCAT_CA_CERT_LOCATION>/test-keystore/tomcat.keystore</SSL_TOMCAT_CA_CERT_LOCATION>
                                     <CAF_JOB_SERVICE_JOB_TYPE_DEFINITIONS_DIR>/test-job-type-definitions</CAF_JOB_SERVICE_JOB_TYPE_DEFINITIONS_DIR>
 
-                                    <CAF_JOB_SERVICE_JOB_TYPE_BASIC_TASK_PIPE>basic task-pipe</CAF_JOB_SERVICE_JOB_TYPE_BASIC_TASK_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_BASIC_TARGET_PIPE>basic target-pipe</CAF_JOB_SERVICE_JOB_TYPE_BASIC_TARGET_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TASK_PIPE>config task-pipe</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TASK_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TARGET_PIPE>config target-pipe</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TARGET_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_UPPER>upper value</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_UPPER>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_LOWER>lower value</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_LOWER>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_MULTIPLE>multiple value</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_MULTIPLE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_NODESC>nodesc value</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_NODESC>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_CONFIG_NUMBER>123</CAF_JOB_SERVICE_JOB_TYPE_CONFIG_NUMBER>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TASK_PIPE>params task-pipe</CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TASK_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TARGET_PIPE>params target-pipe</CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TARGET_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE>complex task-pipe</CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE>complex target-pipe</CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_INVALID-OUTPUT_TASK_PIPE>invalid-output task-pipe</CAF_JOB_SERVICE_JOB_TYPE_INVALID-OUTPUT_TASK_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_INVALID-OUTPUT_TARGET_PIPE>invalid-output target-pipe</CAF_JOB_SERVICE_JOB_TYPE_INVALID-OUTPUT_TARGET_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_EMPTY-TARGET-PIPE_TASK_PIPE>empty-target-pipe task-pipe</CAF_JOB_SERVICE_JOB_TYPE_EMPTY-TARGET-PIPE_TASK_PIPE>
-                                    <CAF_JOB_SERVICE_JOB_TYPE_EMPTY-TARGET-PIPE_TARGET_PIPE></CAF_JOB_SERVICE_JOB_TYPE_EMPTY-TARGET-PIPE_TARGET_PIPE>
+                                    <JOB_TYPE_BASIC_TASK_PIPE>basic task-pipe</JOB_TYPE_BASIC_TASK_PIPE>
+                                    <JOB_TYPE_BASIC_TARGET_PIPE>basic target-pipe</JOB_TYPE_BASIC_TARGET_PIPE>
+                                    <JOB_TYPE_CONFIG_TASK_PIPE>config task-pipe</JOB_TYPE_CONFIG_TASK_PIPE>
+                                    <JOB_TYPE_CONFIG_TARGET_PIPE>config target-pipe</JOB_TYPE_CONFIG_TARGET_PIPE>
+                                    <JOB_TYPE_CONFIG_UPPER>upper value</JOB_TYPE_CONFIG_UPPER>
+                                    <JOB_TYPE_CONFIG_LOWER>lower value</JOB_TYPE_CONFIG_LOWER>
+                                    <JOB_TYPE_CONFIG_MULTIPLE>multiple value</JOB_TYPE_CONFIG_MULTIPLE>
+                                    <JOB_TYPE_CONFIG_NODESC>nodesc value</JOB_TYPE_CONFIG_NODESC>
+                                    <JOB_TYPE_CONFIG_NUMBER>123</JOB_TYPE_CONFIG_NUMBER>
+                                    <JOB_TYPE_PARAMS_TASK_PIPE>params task-pipe</JOB_TYPE_PARAMS_TASK_PIPE>
+                                    <JOB_TYPE_PARAMS_TARGET_PIPE>params target-pipe</JOB_TYPE_PARAMS_TARGET_PIPE>
+                                    <JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE>complex task-pipe</JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE>
+                                    <JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE>complex target-pipe</JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE>
+                                    <JOB_TYPE_INVALID-OUTPUT_TASK_PIPE>invalid-output task-pipe</JOB_TYPE_INVALID-OUTPUT_TASK_PIPE>
+                                    <JOB_TYPE_INVALID-OUTPUT_TARGET_PIPE>invalid-output target-pipe</JOB_TYPE_INVALID-OUTPUT_TARGET_PIPE>
+                                    <JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE>null-target-pipe task-pipe</JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE>
                                 </env>
                                 <volumes>
                                     <from>

--- a/job-service-container/src/test/java/com/hpe/caf/services/job/api/JobServiceIT.java
+++ b/job-service-container/src/test/java/com/hpe/caf/services/job/api/JobServiceIT.java
@@ -880,19 +880,19 @@ public class JobServiceIT {
 
         final JobTypeTestTaskData messageTaskData
             = objectMapper.readValue(messageRetriever.get().getTaskData(), JobTypeTestTaskData.class);
-        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_UPPER"), "upper value",
+        assertEquals(messageTaskData.config.get("CAF_JOB_SERVICE_JOB_TYPE_CONFIG_UPPER"), "upper value",
                      "property with upper-case name should be passed to task data script");
-        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_lower"), "lower value",
+        assertEquals(messageTaskData.config.get("CAF_JOB_SERVICE_JOB_TYPE_CONFIG_lower"), "lower value",
                      "property with lower-case name should be passed to task data script");
-        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_multiple"), "multiple value",
+        assertEquals(messageTaskData.config.get("CAF_JOB_SERVICE_JOB_TYPE_CONFIG_multiple"), "multiple value",
                      "property specified with multiple cases should be passed to task data script "
                      + "in lower-case variant");
-        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_MULTIPLE"), "multiple value",
+        assertEquals(messageTaskData.config.get("CAF_JOB_SERVICE_JOB_TYPE_CONFIG_MULTIPLE"), "multiple value",
                      "property specified with multiple cases should be passed to task data script "
                      + "in upper-case variant");
-        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_nodesc"), "nodesc value",
+        assertEquals(messageTaskData.config.get("CAF_JOB_SERVICE_JOB_TYPE_CONFIG_nodesc"), "nodesc value",
                      "property with no description should be passed to task data script");
-        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_number"), "123",
+        assertEquals(messageTaskData.config.get("CAF_JOB_SERVICE_JOB_TYPE_CONFIG_number"), "123",
                      "property with numeric value should be passed to task data script as string");
     }
 

--- a/job-service-container/src/test/java/com/hpe/caf/services/job/api/JobServiceIT.java
+++ b/job-service-container/src/test/java/com/hpe/caf/services/job/api/JobServiceIT.java
@@ -878,22 +878,22 @@ public class JobServiceIT {
         final NewJob newJob = makeRestrictedJob(jobId, "config", null);
         jobsApi.createOrUpdateJob(defaultPartitionId, jobId, newJob, correlationId);
 
-        final JobTypeTestTaskData messageTaskData =
-            objectMapper.readValue(messageRetriever.get().getTaskData(), JobTypeTestTaskData.class);
-        assertEquals(messageTaskData.config.get("UPPER"), "upper value",
-            "property with upper-case name should be passed to task data script");
-        assertEquals(messageTaskData.config.get("lower"), "lower value",
-            "property with lower-case name should be passed to task data script");
-        assertEquals(messageTaskData.config.get("multiple"), "multiple value",
-            "property specified with multiple cases should be passed to task data script " +
-                "in lower-case variant");
-        assertEquals(messageTaskData.config.get("MULTIPLE"), "multiple value",
-            "property specified with multiple cases should be passed to task data script " +
-                "in upper-case variant");
-        assertEquals(messageTaskData.config.get("nodesc"), "nodesc value",
-            "property with no description should be passed to task data script");
-        assertEquals(messageTaskData.config.get("number"), "123",
-            "property with numeric value should be passed to task data script as string");
+        final JobTypeTestTaskData messageTaskData
+            = objectMapper.readValue(messageRetriever.get().getTaskData(), JobTypeTestTaskData.class);
+        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_UPPER"), "upper value",
+                     "property with upper-case name should be passed to task data script");
+        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_lower"), "lower value",
+                     "property with lower-case name should be passed to task data script");
+        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_multiple"), "multiple value",
+                     "property specified with multiple cases should be passed to task data script "
+                     + "in lower-case variant");
+        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_MULTIPLE"), "multiple value",
+                     "property specified with multiple cases should be passed to task data script "
+                     + "in upper-case variant");
+        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_nodesc"), "nodesc value",
+                     "property with no description should be passed to task data script");
+        assertEquals(messageTaskData.config.get("JOB_TYPE_CONFIG_number"), "123",
+                     "property with numeric value should be passed to task data script as string");
     }
 
     @Test
@@ -935,12 +935,12 @@ public class JobServiceIT {
     }
 
     @Test
-    public void testCreateRestrictedJobWithEmptyTargetPipe() throws Exception {
-        testQueueManager = getQueueManager("empty-target-pipe task-pipe");
+    public void testCreateRestrictedJobWithNullTargetPipe() throws Exception {
+        testQueueManager = getQueueManager("null-target-pipe task-pipe");
         final Supplier<TaskMessage> messageRetriever = getMessageFromQueue(testQueueManager);
         final String jobId = UUID.randomUUID().toString();
         final String correlationId = "1";
-        final NewJob newJob = makeRestrictedJob(jobId, "empty-target-pipe", null);
+        final NewJob newJob = makeRestrictedJob(jobId, "null-target-pipe", null);
         jobsApi.createOrUpdateJob(defaultPartitionId, jobId, newJob, correlationId);
 
         final TaskMessage messageTask = messageRetriever.get();

--- a/job-service-container/src/test/resources/job-type-definitions/basic.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/basic.yaml
@@ -15,20 +15,20 @@
 #
 
 configurationProperties:
-  - name: TASK_PIPE
-  - name: TARGET_PIPE
+  - name: JOB_TYPE_BASIC_TASK_PIPE
+  - name: JOB_TYPE_BASIC_TARGET_PIPE
 taskScript: |
   {
     "taskClassifier": "basic classifier",
     "taskApiVersion": 74,
     "taskData": {
       "config": .configuration,
-      "taskQueue":.configuration.TASK_PIPE,
-      "targetQueue": .configuration.TARGET_PIPE,
+      "taskQueue":.configuration.JOB_TYPE_BASIC_TASK_PIPE,
+      "targetQueue": .configuration.JOB_TYPE_BASIC_TARGET_PIPE,
       "partitionIdent": .partitionId,
       "jobIdent": .jobId,
       "reqParams": .parameters
     },
-    "taskPipe": .configuration.TASK_PIPE,
-    "targetPipe": .configuration.TARGET_PIPE
+    "taskPipe": .configuration.JOB_TYPE_BASIC_TASK_PIPE,
+    "targetPipe": .configuration.JOB_TYPE_BASIC_TARGET_PIPE
   }

--- a/job-service-container/src/test/resources/job-type-definitions/basic.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/basic.yaml
@@ -15,20 +15,20 @@
 #
 
 configurationProperties:
-  - name: JOB_TYPE_BASIC_TASK_PIPE
-  - name: JOB_TYPE_BASIC_TARGET_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_BASIC_TASK_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_BASIC_TARGET_PIPE
 taskScript: |
   {
     "taskClassifier": "basic classifier",
     "taskApiVersion": 74,
     "taskData": {
       "config": .configuration,
-      "taskQueue":.configuration.JOB_TYPE_BASIC_TASK_PIPE,
-      "targetQueue": .configuration.JOB_TYPE_BASIC_TARGET_PIPE,
+      "taskQueue":.configuration.CAF_JOB_SERVICE_JOB_TYPE_BASIC_TASK_PIPE,
+      "targetQueue": .configuration.CAF_JOB_SERVICE_JOB_TYPE_BASIC_TARGET_PIPE,
       "partitionIdent": .partitionId,
       "jobIdent": .jobId,
       "reqParams": .parameters
     },
-    "taskPipe": .configuration.JOB_TYPE_BASIC_TASK_PIPE,
-    "targetPipe": .configuration.JOB_TYPE_BASIC_TARGET_PIPE
+    "taskPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_BASIC_TASK_PIPE,
+    "targetPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_BASIC_TARGET_PIPE
   }

--- a/job-service-container/src/test/resources/job-type-definitions/complex-transform.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/complex-transform.yaml
@@ -25,8 +25,8 @@ jobParametersSchema:
       type: object
       additionalProperties: { type: number }
 configurationProperties:
-  - name: TASK_PIPE
-  - name: TARGET_PIPE
+  - name: JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE
+  - name: JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE
 taskScript: |
     { "taskClassifier": "classifier",
       "taskApiVersion": 1,
@@ -39,6 +39,6 @@ taskScript: |
           }
         }
       },
-      "taskPipe": .configuration.TASK_PIPE,
-      "targetPipe": .configuration.TARGET_PIPE
+      "taskPipe": .configuration.JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE,
+      "targetPipe": .configuration.JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE
     }

--- a/job-service-container/src/test/resources/job-type-definitions/complex-transform.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/complex-transform.yaml
@@ -25,8 +25,8 @@ jobParametersSchema:
       type: object
       additionalProperties: { type: number }
 configurationProperties:
-  - name: JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE
-  - name: JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE
 taskScript: |
     { "taskClassifier": "classifier",
       "taskApiVersion": 1,
@@ -39,6 +39,6 @@ taskScript: |
           }
         }
       },
-      "taskPipe": .configuration.JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE,
-      "targetPipe": .configuration.JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE
+      "taskPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TASK_PIPE,
+      "targetPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_COMPLEX-TRANSFORM_TARGET_PIPE
     }

--- a/job-service-container/src/test/resources/job-type-definitions/config.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/config.yaml
@@ -15,23 +15,23 @@
 #
 
 configurationProperties:
-  - name: JOB_TYPE_CONFIG_UPPER
+  - name: CAF_JOB_SERVICE_JOB_TYPE_CONFIG_UPPER
     description: upper desc
-  - name: JOB_TYPE_CONFIG_lower
+  - name: CAF_JOB_SERVICE_JOB_TYPE_CONFIG_lower
     description: lower desc
-  - name: JOB_TYPE_CONFIG_multiple
+  - name: CAF_JOB_SERVICE_JOB_TYPE_CONFIG_multiple
     description: multiple desc
-  - name: JOB_TYPE_CONFIG_MULTIPLE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_CONFIG_MULTIPLE
     description: multiple desc
-  - name: JOB_TYPE_CONFIG_nodesc
-  - name: JOB_TYPE_CONFIG_number
+  - name: CAF_JOB_SERVICE_JOB_TYPE_CONFIG_nodesc
+  - name: CAF_JOB_SERVICE_JOB_TYPE_CONFIG_number
     description: number desc
-  - name: JOB_TYPE_CONFIG_TASK_PIPE
-  - name: JOB_TYPE_CONFIG_TARGET_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TASK_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TARGET_PIPE
 taskScript: |
   { "taskClassifier": "classifier",
     "taskApiVersion": 1,
     "taskData": { "config": .configuration },
-    "taskPipe": .configuration.JOB_TYPE_CONFIG_TASK_PIPE,
-    "targetPipe": .configuration.JOB_TYPE_CONFIG_TARGET_PIPE
+    "taskPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TASK_PIPE,
+    "targetPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_CONFIG_TARGET_PIPE
   }

--- a/job-service-container/src/test/resources/job-type-definitions/config.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/config.yaml
@@ -15,23 +15,23 @@
 #
 
 configurationProperties:
-  - name: UPPER
+  - name: JOB_TYPE_CONFIG_UPPER
     description: upper desc
-  - name: lower
+  - name: JOB_TYPE_CONFIG_lower
     description: lower desc
-  - name: multiple
+  - name: JOB_TYPE_CONFIG_multiple
     description: multiple desc
-  - name: MULTIPLE
+  - name: JOB_TYPE_CONFIG_MULTIPLE
     description: multiple desc
-  - name: nodesc
-  - name: number
+  - name: JOB_TYPE_CONFIG_nodesc
+  - name: JOB_TYPE_CONFIG_number
     description: number desc
-  - name: TASK_PIPE
-  - name: TARGET_PIPE
+  - name: JOB_TYPE_CONFIG_TASK_PIPE
+  - name: JOB_TYPE_CONFIG_TARGET_PIPE
 taskScript: |
   { "taskClassifier": "classifier",
     "taskApiVersion": 1,
     "taskData": { "config": .configuration },
-    "taskPipe": .configuration.TASK_PIPE,
-    "targetPipe": .configuration.TARGET_PIPE
+    "taskPipe": .configuration.JOB_TYPE_CONFIG_TASK_PIPE,
+    "targetPipe": .configuration.JOB_TYPE_CONFIG_TARGET_PIPE
   }

--- a/job-service-container/src/test/resources/job-type-definitions/null-target-pipe.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/null-target-pipe.yaml
@@ -15,15 +15,14 @@
 #
 
 configurationProperties:
-  - name: TASK_PIPE
-  - name: TARGET_PIPE
+  - name: JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE
 taskScript: |
     { "taskClassifier": "classifier",
       "taskApiVersion": 1,
       "taskData": {
-        "targetQueue": .configuration.TARGET_PIPE
+        "targetQueue": .configuration.JOB_TYPE_NULL-TARGET-PIPE_TARGET_PIPE
       },
-      "taskPipe": .configuration.TASK_PIPE,
-      "targetPipe": .configuration.TARGET_PIPE
+      "taskPipe": .configuration.JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE,
+      "targetPipe": .configuration.JOB_TYPE_NULL-TARGET-PIPE_TARGET_PIPE
     }
 

--- a/job-service-container/src/test/resources/job-type-definitions/null-target-pipe.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/null-target-pipe.yaml
@@ -15,14 +15,14 @@
 #
 
 configurationProperties:
-  - name: JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE
 taskScript: |
     { "taskClassifier": "classifier",
       "taskApiVersion": 1,
       "taskData": {
-        "targetQueue": .configuration.JOB_TYPE_NULL-TARGET-PIPE_TARGET_PIPE
+        "targetQueue": .configuration.CAF_JOB_SERVICE_JOB_TYPE_NULL-TARGET-PIPE_TARGET_PIPE
       },
-      "taskPipe": .configuration.JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE,
-      "targetPipe": .configuration.JOB_TYPE_NULL-TARGET-PIPE_TARGET_PIPE
+      "taskPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_NULL-TARGET-PIPE_TASK_PIPE,
+      "targetPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_NULL-TARGET-PIPE_TARGET_PIPE
     }
 

--- a/job-service-container/src/test/resources/job-type-definitions/params.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/params.yaml
@@ -19,12 +19,12 @@ jobParametersSchema:
   properties: { s: { type: string } }
   additionalProperties: { type: number }
 configurationProperties:
-  - name: JOB_TYPE_PARAMS_TASK_PIPE
-  - name: JOB_TYPE_PARAMS_TARGET_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TASK_PIPE
+  - name: CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TARGET_PIPE
 taskScript: |
     { "taskClassifier": "classifier",
       "taskApiVersion": 1,
       "taskData": { "reqParams": .parameters },
-      "taskPipe": .configuration.JOB_TYPE_PARAMS_TASK_PIPE,
-      "targetPipe": .configuration.JOB_TYPE_PARAMS_TARGET_PIPE
+      "taskPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TASK_PIPE,
+      "targetPipe": .configuration.CAF_JOB_SERVICE_JOB_TYPE_PARAMS_TARGET_PIPE
     }

--- a/job-service-container/src/test/resources/job-type-definitions/params.yaml
+++ b/job-service-container/src/test/resources/job-type-definitions/params.yaml
@@ -19,12 +19,12 @@ jobParametersSchema:
   properties: { s: { type: string } }
   additionalProperties: { type: number }
 configurationProperties:
-  - name: TASK_PIPE
-  - name: TARGET_PIPE
+  - name: JOB_TYPE_PARAMS_TASK_PIPE
+  - name: JOB_TYPE_PARAMS_TARGET_PIPE
 taskScript: |
     { "taskClassifier": "classifier",
       "taskApiVersion": 1,
       "taskData": { "reqParams": .parameters },
-      "taskPipe": .configuration.TASK_PIPE,
-      "targetPipe": .configuration.TARGET_PIPE
+      "taskPipe": .configuration.JOB_TYPE_PARAMS_TASK_PIPE,
+      "targetPipe": .configuration.JOB_TYPE_PARAMS_TARGET_PIPE
     }

--- a/job-service/src/main/java/com/hpe/caf/services/job/jobtype/DefaultDefinitionParser.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/jobtype/DefaultDefinitionParser.java
@@ -115,18 +115,14 @@ public final class DefaultDefinitionParser implements DefinitionParser {
             final Map<String, String> configuration = new HashMap<>();
             for (final ConfigurationProperty property : properties) {
                 final String propertyName = property.getName(id, this);
-                final String propertyValue = appConfig.getJobTypeProperty(id, propertyName);
+                final String propertyValue = appConfig.getJobProperty(propertyName);
                 if (propertyValue == null) {
                     throw new InvalidJobTypeDefinitionException(
                         id + ": configuration is not available: " + propertyName);
                 }
                 // preserve property name case in the output, even though the configuration lookup
                 // ignores it
-                if (propertyName.equals("TARGET_PIPE") && propertyValue.equals("")) {
-                    configuration.put(propertyName, null);
-                } else {
-                    configuration.put(propertyName, propertyValue);
-                }
+                configuration.put(propertyName, propertyValue);
             }
 
             return configuration;

--- a/job-service/src/test/java/com/hpe/caf/services/job/jobtype/DefaultDefinitionParserTest.java
+++ b/job-service/src/test/java/com/hpe/caf/services/job/jobtype/DefaultDefinitionParserTest.java
@@ -43,13 +43,11 @@ public class DefaultDefinitionParserTest {
 
     /**
      * Setup AppConfig mock to have the base configuration required for a job type
-     *
-     * @param typeId
      */
-    private void setupValidConfig(final String typeId) {
-        Mockito.when(appConfig.getJobTypeProperty(typeId, "TASK_PIPE"))
+    private void setupValidConfig() {
+        Mockito.when(appConfig.getJobProperty("TASK_PIPE"))
             .thenReturn("basic task pipe");
-        Mockito.when(appConfig.getJobTypeProperty(typeId, "TARGET_PIPE"))
+        Mockito.when(appConfig.getJobProperty("TARGET_PIPE"))
             .thenReturn("basic target pipe");
     }
 
@@ -79,7 +77,7 @@ public class DefaultDefinitionParserTest {
 
     @Test
     public void testBasicDefinition() throws Exception {
-        setupValidConfig("basic-id");
+        setupValidConfig();
         final JobType jobType =
             new DefaultDefinitionParser(appConfig).parse("basic-id", getDefinition("basic"));
         final WorkerAction task =
@@ -123,7 +121,7 @@ public class DefaultDefinitionParserTest {
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testInputStreamError() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         new DefaultDefinitionParser(appConfig).parse("id", new InputStream() {
             @Override
             public int read() throws IOException { throw new IOException("disk error"); }
@@ -132,13 +130,13 @@ public class DefaultDefinitionParserTest {
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testInvalidYamlSyntax() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         new DefaultDefinitionParser(appConfig).parse("id", getDefinition("invalid-yaml-syntax"));
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testInvalidTaskScriptSyntax() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         new DefaultDefinitionParser(appConfig).parse("id", getDefinition("invalid-taskscript-syntax"));
     }
 
@@ -149,96 +147,80 @@ public class DefaultDefinitionParserTest {
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testMissingTaskClassifier() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("missing-taskclassifier"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testTaskClassifierWithWrongType() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("wrongtype-taskclassifier"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testEmptyStringTaskClassifier() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("empty-taskclassifier"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testMissingTaskApiVersion() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("missing-taskapiversion"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testTaskApiVersionWithWrongType() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("wrongtype-taskapiversion"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testMissingTaskData() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("missing-taskdata"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testTaskDataWithWrongType() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("wrongtype-taskdata"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testTaskPipeMissingFromConfig() throws Exception {
-        Mockito.when(appConfig.getJobTypeProperty("id", "TASK_PIPE")).thenReturn(null);
-        Mockito.when(appConfig.getJobTypeProperty("id", "TARGET_PIPE")).thenReturn("basic target pipe");
+        Mockito.when(appConfig.getJobProperty("TASK_PIPE")).thenReturn(null);
+        Mockito.when(appConfig.getJobProperty("TARGET_PIPE")).thenReturn("basic target pipe");
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("basic"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testEmptyStringTaskPipe() throws Exception {
-        Mockito.when(appConfig.getJobTypeProperty("id", "TASK_PIPE")).thenReturn("");
-        Mockito.when(appConfig.getJobTypeProperty("id", "TARGET_PIPE")).thenReturn("basic target pipe");
+        Mockito.when(appConfig.getJobProperty("TASK_PIPE")).thenReturn("");
+        Mockito.when(appConfig.getJobProperty("TARGET_PIPE")).thenReturn("basic target pipe");
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("basic"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testTargetPipeMissingFromConfig() throws Exception {
-        Mockito.when(appConfig.getJobTypeProperty("id", "TASK_PIPE")).thenReturn("basic task pipe");
-        Mockito.when(appConfig.getJobTypeProperty("id", "TARGET_PIPE")).thenReturn(null);
+        Mockito.when(appConfig.getJobProperty("TASK_PIPE")).thenReturn("basic task pipe");
+        Mockito.when(appConfig.getJobProperty("TARGET_PIPE")).thenReturn(null);
         final JobType jobType = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("basic"));
         jobType.buildTask("partition id", "id", NullNode.getInstance());
     }
 
     @Test
-    public void testTargetPipeIsSetToNullOnWorkerTaskWhenConfigValueIsEmptyString() throws Exception {
-        Mockito.when(appConfig.getJobTypeProperty("id", "TASK_PIPE"))
-            .thenReturn("basic task pipe");
-        Mockito.when(appConfig.getJobTypeProperty("id", "TARGET_PIPE"))
-            .thenReturn("");
-        
-        final JobType jobType
-            = new DefaultDefinitionParser(appConfig).parse("id", getDefinition("basic"));
-        final WorkerAction task
-            = jobType.buildTask("partition id", "job id", NullNode.getInstance());
-
-        Assert.assertEquals("targetPipe should be set to null on the WorkerTask when the configuration value is an empty string",
-                            null, task.getTargetPipe());
-    }
-
-    @Test
     public void testConfigurationProperties() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType =
             new DefaultDefinitionParser(appConfig).parse("id", getDefinition("config"));
         final WorkerAction task =
@@ -255,15 +237,15 @@ public class DefaultDefinitionParserTest {
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testConfigurationPropertiesWithMissingName() throws Exception {
-        setupValidConfig("id");
-        Mockito.when(appConfig.getJobTypeProperty("id", "prop_a")).thenReturn("value a");
-        Mockito.when(appConfig.getJobTypeProperty("id", "prop_b")).thenReturn("value b");
+        setupValidConfig();
+        Mockito.when(appConfig.getJobProperty("prop_a")).thenReturn("value a");
+        Mockito.when(appConfig.getJobProperty("prop_b")).thenReturn("value b");
         new DefaultDefinitionParser(appConfig).parse("id", getDefinition("missing-config-name"));
     }
 
     @Test
     public void testJobParametersSchemaValidation() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         final JobType jobType =
             new DefaultDefinitionParser(appConfig).parse("id", getDefinition("job-parameters-schema-expects-string"));
 
@@ -277,7 +259,7 @@ public class DefaultDefinitionParserTest {
 
     @Test(expected = InvalidJobTypeDefinitionException.class)
     public void testMissingTaskScript() throws Exception {
-        setupValidConfig("id");
+        setupValidConfig();
         new DefaultDefinitionParser(appConfig).parse("id", getDefinition("missing-taskscript"));
     }
 

--- a/release-notes-4.0.0.md
+++ b/release-notes-4.0.0.md
@@ -4,11 +4,13 @@
 ${version-number}
 
 #### Breaking Changes
-- SCMOD-12505: Job type yaml definition updated.  
-  The `taskDataScript` property should no longer be provided when adding a new job type yaml file. Instead, a `taskScript` property
+- SCMOD-12505: Various updates to the 'Job Types' functionality.  
+  - The `taskDataScript` property should no longer be provided when adding a new job type yaml file. Instead, a `taskScript` property
   should be provided. See the [Job-Types](https://jobservice.github.io/job-service/pages/en-us/Job-Types) documentation for more
   information.
+  - The names used for the `configurationProperties` now have a direct mapping to the environment variables used to populate them. For
+  example, if a configuration property is named `TASK_PIPE` in a job type yaml definition, then the value for that configuration property
+ is expected to be available in an environment variable named `TASK_PIPE`.
 
 #### Known Issues
 - None
-


### PR DESCRIPTION
Jira: https://portal.digitalsafe.net/browse/SCMOD-12505

The names used for the `configurationProperties` now have a direct mapping to the environment variables used to populate them. For example, if a configuration property is named `TASK_PIPE` in a job type yaml definition, then the value for that configuration property is expected to be available in an environment variable named `TASK_PIPE`. There is no longer a requirement that the env variable must start with `CAF_JOB_SERVICE_JOB_TYPE_<JOB-TYPE-ID>_...`