### PR TITLE
SCMOD-12346 Changes to include correlation id in tracking task messages

### DIFF
--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingReportUpdateWorker.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingReportUpdateWorker.java
@@ -124,7 +124,8 @@ public final class JobTrackingReportUpdateWorker extends AbstractWorker<Tracking
             //  messaging queue.
             for (final JobTrackingWorkerDependency dependency : jobDependencyList) {
                 final TaskMessage dependentJobTaskMessage =
-                        JobTrackingWorkerUtil.createDependentJobTaskMessage(dependency, workerTask.getTo());
+                        JobTrackingWorkerUtil.createDependentJobTaskMessage(dependency, workerTask.getTo(),
+                            workerTask.getCorrelationId());
                 workerTask.sendMessage(dependentJobTaskMessage);
             }
         }

--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingReportUpdateWorker.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingReportUpdateWorker.java
@@ -123,9 +123,9 @@ public final class JobTrackingReportUpdateWorker extends AbstractWorker<Tracking
             //  For each dependent job, create a TaskMessage object and publish to the
             //  messaging queue.
             for (final JobTrackingWorkerDependency dependency : jobDependencyList) {
-                final TaskMessage dependentJobTaskMessage =
-                        JobTrackingWorkerUtil.createDependentJobTaskMessage(dependency, workerTask.getTo(),
-                            workerTask.getCorrelationId());
+                final TaskMessage dependentJobTaskMessage = JobTrackingWorkerUtil.createDependentJobTaskMessage(
+                    dependency, workerTask.getTo(), workerTask.getCorrelationId());
+
                 workerTask.sendMessage(dependentJobTaskMessage);
             }
         }

--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerFactory.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerFactory.java
@@ -384,21 +384,21 @@ public class JobTrackingWorkerFactory implements WorkerFactory, TaskMessageForwa
 
     /**
      *  Start the list of jobs that are now available to be run.
-     *  @param jobDependencyList containing any dependent jobs that are now available for processing
+     *
+     * @param jobDependencyList containing any dependent jobs that are now available for processing
      * @param callback worker callback to enact the forwarding action determined by the worker
      * @param trackingPipe target pipe where dependent jobs should be forwarded to.
-     * @param correlationId
      */
     private void forwardAvailableJobs(final List<JobTrackingWorkerDependency> jobDependencyList,
-        final WorkerCallback callback, final String trackingPipe,
-        String correlationId, TaskInformation taskInformation)
+                                      final WorkerCallback callback, final String trackingPipe,
+                                      final String correlationId,
+                                      TaskInformation taskInformation)
     {
         // Walk the resultSet placing each returned job on the Rabbit Queue
         try {
             for (final JobTrackingWorkerDependency jobDependency : jobDependencyList) {
                 final TaskMessage dependentJobTaskMessage =
-                        JobTrackingWorkerUtil.createDependentJobTaskMessage(jobDependency, trackingPipe,
-                            correlationId);
+                        JobTrackingWorkerUtil.createDependentJobTaskMessage(jobDependency, trackingPipe, correlationId);
 
                 callback.send(taskInformation, dependentJobTaskMessage);
             }
@@ -628,9 +628,8 @@ public class JobTrackingWorkerFactory implements WorkerFactory, TaskMessageForwa
 
                 // For each dependent job, create a TaskMessage object and publish to the messaging queue
                 for (final JobTrackingWorkerDependency dependency : jobDependencyList) {
-                    final TaskMessage dependentJobTaskMessage
-                        = JobTrackingWorkerUtil.createDependentJobTaskMessage(dependency, workerTask.getTo(),
-                        workerTask.getCorrelationId());
+                    final TaskMessage dependentJobTaskMessage = JobTrackingWorkerUtil.createDependentJobTaskMessage(
+                        dependency, workerTask.getTo(), workerTask.getCorrelationId());
 
                     workerTask.sendMessage(dependentJobTaskMessage);
                 }

--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerFactory.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerFactory.java
@@ -257,7 +257,11 @@ public class JobTrackingWorkerFactory implements WorkerFactory, TaskMessageForwa
         if (!jobDependencyList.isEmpty()) {
             // Forward any dependent jobs which are now available for processing
             try {
-                forwardAvailableJobs(jobDependencyList, callback, proxiedTaskMessage.getTracking().getTrackingPipe(), proxiedTaskMessage.getCorrelationId(), taskInformation);
+                forwardAvailableJobs(jobDependencyList,
+                                     callback,
+                                     proxiedTaskMessage.getTracking().getTrackingPipe(),
+                                     proxiedTaskMessage.getCorrelationId(),
+                                     taskInformation);
             } catch (Exception e) {
                 LOG.error("Failed to create dependent jobs.");
                 throw new RuntimeException("Failed to create dependent jobs.", e);

--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerUtil.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerUtil.java
@@ -36,13 +36,13 @@ public final class JobTrackingWorkerUtil
 
     /**
      *  Start the list of jobs that are now available to be run.
-     *  @param jobDependency dependent job that is now available for processing
+     *
+     * @param jobDependency dependent job that is now available for processing
      * @param trackingPipe target pipe where dependent jobs should be forwarded to.
-     * @param correlationId
      */
-    public static TaskMessage createDependentJobTaskMessage(
-        final JobTrackingWorkerDependency jobDependency,
-        final String trackingPipe, String correlationId)
+    public static TaskMessage createDependentJobTaskMessage(final JobTrackingWorkerDependency jobDependency,
+                                                            final String trackingPipe,
+                                                            final String correlationId)
     {
         //  Generate a random task id.
         final String taskId = UUID.randomUUID().toString();

--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerUtil.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerUtil.java
@@ -36,12 +36,13 @@ public final class JobTrackingWorkerUtil
 
     /**
      *  Start the list of jobs that are now available to be run.
-     *
-     * @param jobDependency dependent job that is now available for processing
+     *  @param jobDependency dependent job that is now available for processing
      * @param trackingPipe target pipe where dependent jobs should be forwarded to.
+     * @param correlationId
      */
-    public static TaskMessage createDependentJobTaskMessage(final JobTrackingWorkerDependency jobDependency,
-                                                            final String trackingPipe)
+    public static TaskMessage createDependentJobTaskMessage(
+        final JobTrackingWorkerDependency jobDependency,
+        final String trackingPipe, String correlationId)
     {
         //  Generate a random task id.
         final String taskId = UUID.randomUUID().toString();
@@ -71,7 +72,9 @@ public final class JobTrackingWorkerUtil
                 TaskStatus.NEW_TASK,
                 Collections.<String, byte[]>emptyMap(),
                 jobDependency.getTaskPipe(),
-                trackingInfo);
+                trackingInfo,
+                null,
+                correlationId);
     }
 
     /**


### PR DESCRIPTION
Opened this PR for purpose of discussion along with review. This is to address the issue of correlation idz not coming up in the tracing logs.
Looked at the places where new TaskMessage was getting created. Found [these](http://16.103.38.246:9090/search?group=1_verity&group=2_caf&group=3_Other-FAS-Libraries&full=%22new+TaskMessage%22&defs=&refs=&path=-test+-testing+-worker%5C-elastic%5C-testing%5C-util&hist=&type=&xrd=&nn=3). Made changes to the ones referring to tracking worker. 
