### PR TITLE
SCMOD-12730: Maintain existing status checking behaviour

### DIFF
--- a/job-service-container/src/test/java/com/hpe/caf/services/job/api/JobServiceOutputDeliveryHandler.java
+++ b/job-service-container/src/test/java/com/hpe/caf/services/job/api/JobServiceOutputDeliveryHandler.java
@@ -91,17 +91,7 @@ public class JobServiceOutputDeliveryHandler implements ResultHandler {
                                 trackTo));
             }
 
-            final Date lastStatusCheckTime = tracking.getLastStatusCheckTime();
-            final boolean lastStatusCheckTimeEqual = expectation.getLastStatusCheckTime() == null ? lastStatusCheckTime == null
-                : expectation.getLastStatusCheckTime().equals(lastStatusCheckTime);
-            if (!lastStatusCheckTimeEqual) {
-                context.failed(new TestItem(taskMessage.getTaskId(), null, null),
-                               MessageFormat.format(
-                                   "In the forwarded task message, expected lastStatusCheckTime field as {0} but found {1} in the"
-                                   + "tracking info.",
-                                   expectation.getLastStatusCheckTime(),
-                                   lastStatusCheckTime));
-            }
+            // Can't compare lastStatusCheckTime as we don't know what time it would have been set to.
 
             final long statusCheckIntervalMillis = tracking.getStatusCheckIntervalMillis();
             if (expectation.getStatusCheckIntervalMillis() != statusCheckIntervalMillis) {

--- a/job-service-scheduled-executor/src/main/java/com/hpe/caf/services/job/scheduled/executor/QueueServices.java
+++ b/job-service-scheduled-executor/src/main/java/com/hpe/caf/services/job/scheduled/executor/QueueServices.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
@@ -115,7 +116,7 @@ public final class QueueServices
         LOG.debug("Constructing the task message ...");
         final TrackingInfo trackingInfo = new TrackingInfo(
                 new JobTaskId(partitionId, jobId).getMessageId(),
-                null,
+                new Date(),
                 getStatusCheckIntervalMillis(ScheduledExecutorConfig.getStatusCheckIntervalSeconds()),
                 statusCheckUrl, ScheduledExecutorConfig.getTrackingPipe(), workerAction.getTargetPipe());
 

--- a/job-service/src/main/java/com/hpe/caf/services/job/queue/QueueServices.java
+++ b/job-service/src/main/java/com/hpe/caf/services/job/queue/QueueServices.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
@@ -106,7 +107,7 @@ public final class QueueServices {
         //  Construct the task message.
         final TrackingInfo trackingInfo = new TrackingInfo(
                 new JobTaskId(partitionId, jobId).getMessageId(),
-                null,
+                new Date(),
                 getStatusCheckIntervalMillis(config.getStatusCheckIntervalSeconds()),
                 statusCheckUrl, config.getTrackingPipe(), workerAction.getTargetPipe());
 

--- a/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerUtil.java
+++ b/worker-jobtracking/src/main/java/com/hpe/caf/worker/jobtracking/JobTrackingWorkerUtil.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.UriBuilder;
 import java.util.Collections;
+import java.util.Date;
 import java.util.UUID;
 
 public final class JobTrackingWorkerUtil
@@ -60,7 +61,7 @@ public final class JobTrackingWorkerUtil
 
         final TrackingInfo trackingInfo = new TrackingInfo(
                 new JobTaskId(jobDependency.getPartitionId(), jobDependency.getJobId()).getMessageId(),
-                null, getStatusCheckIntervalMillis(statusCheckIntervalSeconds), statusCheckUrl, trackingPipe, jobDependency.getTargetPipe());
+                new Date(), getStatusCheckIntervalMillis(statusCheckIntervalSeconds), statusCheckUrl, trackingPipe, jobDependency.getTargetPipe());
 
         return new TaskMessage(
                 taskId,


### PR DESCRIPTION
Previously, the `statusCheckTime` was always set to now + 5 seconds whenever the Job Service created a `TrackingInfo` object. This meant that when a worker first received a task, it only checked the status if 5 seconds had elapsed.

https://github.com/WorkerFramework/worker-framework/blob/v4.0.0/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerCore.java#L242

```
Date statusCheckTime = tracking.getStatusCheckTime();
if (statusCheckTime == null || statusCheckTime.getTime() <= System.currentTimeMillis()) {
    return performJobStatusCheck(tm);
}
```

When I updated `TrackingInfo` to add a `lastStatusCheck` time, I set it to null in the TrackingInfo as that felt like the correct thing to do (i.e. since the status has not been checked yet). However, this now means when the worker first receives a task, it checks if `lastStatusCheckTime` is null, and if so, it will check the status - i.e. workers check the status immediately now rather than after 5 seconds.

https://github.com/WorkerFramework/worker-framework/blob/develop/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerCore.java#L301

```
final Date lastStatusCheckTime = tracking.getLastStatusCheckTime();
final long nextStatusCheckTime = lastStatusCheckTime != null ?
    lastStatusCheckTime.getTime() + tracking.getStatusCheckIntervalMillis() : 0L;
if (lastStatusCheckTime == null || (nextStatusCheckTime <= System.currentTimeMillis())) {
    return performJobStatusCheck(tm);
}
```

I'm guessing we want to maintain the existing behavior of having a worker first checking the status after 5 seconds, there's maybe no point in checking immediately after the task has been created by the Job Service.