### PR TITLE
Remove extra drop function

### DIFF
--- a/job-service-db/src/main/resources/db/migration/V4__drop_unused_functions.sql
+++ b/job-service-db/src/main/resources/db/migration/V4__drop_unused_functions.sql
@@ -73,7 +73,6 @@ DROP FUNCTION IF EXISTS internal_drop_task_tables(
     in_partition_id VARCHAR(40),
     in_task_id VARCHAR(58)
 );
-DROP FUNCTION IF EXISTS get_dependent_jobs();
 DROP FUNCTION IF EXISTS get_job(in_job_id VARCHAR(58));
 DROP FUNCTION IF EXISTS get_job(
     in_partition_id VARCHAR(40),


### PR DESCRIPTION
We use to drop then create the function and this has been replaced with CREATE OR REPLACE so that DROP can be removed. 