### PR TITLE
US572083: Update snakeyaml version to 1.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
             <dependency>
                 <groupId>com.github.cafapi</groupId>
                 <artifactId>caf-dependency-management-bom</artifactId>
-                <version>3.2.0-494</version>
+                <version>3.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/release-notes-6.1.0.md
+++ b/release-notes-6.1.0.md
@@ -4,9 +4,11 @@
 ${version-number}
 
 #### New Features
+- None
 
 #### Patch Fixes Included
 - US572082 - Gson version upgraded to [2.9.1](https://github.com/google/gson/releases/tag/gson-parent-2.9.1)
 - US572083 - Snakeyaml version upgraded to [1.32](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)
 
 #### Known Issues
+- None

--- a/release-notes-6.1.0.md
+++ b/release-notes-6.1.0.md
@@ -7,5 +7,6 @@ ${version-number}
 
 #### Patch Fixes Included
 - US572082 - Gson version upgraded to [2.9.1](https://github.com/google/gson/releases/tag/gson-parent-2.9.1)
+- US572083 - Snakeyaml version upgraded to [1.32](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)
 
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=572083

'caf-dependency-management-bom' updated with snakeyaml version-1.32 in it's '3.3.0-SNAPSHOT' version, that's why job-service upgraded with snapshot version of 'caf-dependency-management-bom'