### PR TITLE
US610049: CVE-2022-40149: Update jettison to 1.5.2

### DIFF
--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -150,6 +150,7 @@
         <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
+            <version>${org.codehaus.jettison.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.workerframework</groupId>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -148,11 +148,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jettison</groupId>
-            <artifactId>jettison</artifactId>
-            <version>${org.codehaus.jettison.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.workerframework</groupId>
             <artifactId>worker-api</artifactId>
         </dependency>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -148,6 +148,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.workerframework</groupId>
             <artifactId>worker-api</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <enforceCorrectDependencies>true</enforceCorrectDependencies>
         <enforceBannedDependencies>true</enforceBannedDependencies>
         <fabric8.docker.maven.version>0.38.1</fabric8.docker.maven.version>
+        <org.codehaus.jettison.version>1.5.2</org.codehaus.jettison.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
         <enforceCorrectDependencies>true</enforceCorrectDependencies>
         <enforceBannedDependencies>true</enforceBannedDependencies>
         <fabric8.docker.maven.version>0.38.1</fabric8.docker.maven.version>
-        <org.codehaus.jettison.version>1.5.2</org.codehaus.jettison.version>
     </properties>
 
     <dependencyManagement>
@@ -262,6 +261,11 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.26</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.5.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=610049