### PR TITLE
Revert "US773019: Upgrade okio to okio-jvm (#353)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,12 +212,6 @@
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-message-prioritization-rerouting</artifactId>
                 <version>1.0.0-97</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.squareup.okio</groupId>
-                        <artifactId>okio</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -241,8 +235,8 @@
             </dependency>
             <dependency>
                 <groupId>com.squareup.okio</groupId>
-                <artifactId>okio-jvm</artifactId>
-                <version>3.5.0</version>
+                <artifactId>okio</artifactId>
+                <version>2.5.0</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp</groupId>


### PR DESCRIPTION
This reverts commit c6f888dc7591d1d68dc5ad3f2eb69eecf7e590c8.

I reverted this because it has broken the scheduled executor, seeing `java.lang.NoClassDefFoundError: okio/Buffer` in the logs.