### PR TITLE
US947054: Lock down images used for db upgrade testing

### DIFF
--- a/job-service-postgres-container/pom.xml
+++ b/job-service-postgres-container/pom.xml
@@ -119,7 +119,7 @@
                         <!-- Run liquibase version of jobservice postgres container against postgres database to install jobservice schema. -->
                         <image>
                             <alias>job-service-postgres-liquibase</alias>
-                            <name>${dockerHubPublic}/jobservice/job-service-postgres:3.5.0</name>
+                            <name>${dockerHubPublic}/jobservice/job-service-postgres-liquibase</name>
                             <run>
                                 <links>
                                     <link>${js.database.host}</link>
@@ -145,7 +145,7 @@
                         <!-- Run flyway version of jobservice postgres container against postgres database to test jobservice schema upgrade. -->
                         <image>
                             <alias>job-service-postgres-flyway</alias>
-                            <name>${projectDockerRegistry}/jobservice/job-service-postgres</name>
+                            <name>${projectDockerRegistry}/jobservice/job-service-postgres-flyway</name>
                             <run>
                                 <links>
                                     <link>${js.database.host}</link>

--- a/job-service-postgres-container/pom.xml
+++ b/job-service-postgres-container/pom.xml
@@ -119,7 +119,7 @@
                         <!-- Run liquibase version of jobservice postgres container against postgres database to install jobservice schema. -->
                         <image>
                             <alias>job-service-postgres-liquibase</alias>
-                            <name>${dockerHubPublic}/jobservice/job-service-postgres-liquibase</name>
+                            <name>${projectDockerRegistry}/jobservice/job-service-postgres-liquibase</name>
                             <run>
                                 <links>
                                     <link>${js.database.host}</link>

--- a/pom.xml
+++ b/pom.xml
@@ -1302,7 +1302,16 @@
                         </image>
                         <image>
                             <repository>${dockerHubPublic}/jobservice/job-service-postgres</repository>
+                            <targetRepository>jobservice/job-service-postgres-liquibase</targetRepository>
+                            <tag>3.5.0</tag>
+                            <latestTag>3.5.0</latestTag>
+                            <digest>sha256:5323cd5945f90795e6448480b8cc622a9472b76f93c0eb97510ca15058e7b337</digest>
+                        </image>
+                        <image>
+                            <repository>${dockerHubPublic}/jobservice/job-service-postgres</repository>
+                            <targetRepository>jobservice/job-service-postgres-flyway</targetRepository>
                             <tag>7.0.2</tag>
+                            <latestTag>7.0.2</latestTag>
                             <digest>sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3</digest>
                         </image>
                         <image>


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=947054