### PR TITLE
US982029: Updates to move to DropWizard 5, Jersey 3.1, Jetty 12

### DIFF
--- a/job-service-dropwizard/pom.xml
+++ b/job-service-dropwizard/pom.xml
@@ -138,12 +138,12 @@
             <artifactId>swagger-ui-dist</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <!--
-            Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
-            This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and a
-            version of DropWizard that includes it is released.
-        -->
         <dependency>
+            <!--
+                Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
+                This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and
+                a version of DropWizard that includes it is released.
+            -->
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
             <scope>runtime</scope>

--- a/job-service-dropwizard/pom.xml
+++ b/job-service-dropwizard/pom.xml
@@ -138,6 +138,16 @@
             <artifactId>swagger-ui-dist</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <!--
+            Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
+            This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and a
+            version of DropWizard that includes it is released.
+        -->
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/job-service-dropwizard/pom.xml
+++ b/job-service-dropwizard/pom.xml
@@ -138,16 +138,6 @@
             <artifactId>swagger-ui-dist</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <!--
-                This is for compatibility with Hibernate Validator 8.
-                dropwizard-validation and jersey-bean-validation are referencing org.glassfish:jakarta.el so that has been excluded.
-                This can probably be removed when DropWizard is updated to use Hibernate Validator 8.
-            -->
-            <groupId>org.glassfish.expressly</groupId>
-            <artifactId>expressly</artifactId>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/job-service-scheduled-executor-container/pom.xml
+++ b/job-service-scheduled-executor-container/pom.xml
@@ -49,6 +49,15 @@
             <groupId>com.github.cafdataprocessing</groupId>
             <artifactId>worker-document</artifactId>
         </dependency>
+        <!--
+            Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
+            This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and a
+            version of DropWizard that includes it is released.
+        -->
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+        </dependency>
     </dependencies>
 	
     <build>

--- a/job-service-scheduled-executor-container/pom.xml
+++ b/job-service-scheduled-executor-container/pom.xml
@@ -49,12 +49,12 @@
             <groupId>com.github.cafdataprocessing</groupId>
             <artifactId>worker-document</artifactId>
         </dependency>
-        <!--
-            Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
-            This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and a
-            version of DropWizard that includes it is released.
-        -->
         <dependency>
+            <!--
+                Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
+                This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and
+                a version of DropWizard that includes it is released.
+            -->
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -552,72 +552,72 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-assets</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-configuration</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-core</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-health</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jackson</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jersey</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jetty</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-lifecycle</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-logging</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-metrics</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-request-logging</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-servlets</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-util</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-validation</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.glassfish</groupId>
@@ -657,7 +657,12 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-jetty11</artifactId>
+                <artifactId>metrics-jetty12</artifactId>
+                <version>4.2.28</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jetty12-ee10</artifactId>
                 <version>4.2.28</version>
             </dependency>
             <dependency>
@@ -713,7 +718,7 @@
             <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
-                <version>5.0.0</version>
+                <version>6.1.0</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.validation</groupId>
@@ -744,6 +749,11 @@
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-agent</artifactId>
                 <version>1.15.7</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-jpms</artifactId>
+                <version>5.15.0</version>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.argparse4j</groupId>
@@ -815,22 +825,22 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-http</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-io</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-security</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.eclipse.jetty.toolchain</groupId>
@@ -840,23 +850,23 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>11.0.24</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlets</artifactId>
-                <version>11.0.24</version>
+                <artifactId>jetty-session</artifactId>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-servlet</artifactId>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.toolchain.setuid</groupId>
-                <artifactId>jetty-setuid-java</artifactId>
-                <version>1.0.4</version>
+                <artifactId>jetty-setuid-jna</artifactId>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.flywaydb</groupId>
@@ -908,32 +918,32 @@
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet-core</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-client</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-common</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-server</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-bean-validation</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.glassfish</groupId>
@@ -944,27 +954,27 @@
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-entity-filtering</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-metainf-services</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.inject</groupId>
                 <artifactId>jersey-hk2</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-json-jackson</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-multipart</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.js</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -618,12 +618,6 @@
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-validation</artifactId>
                 <version>5.0.0-alpha.4</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.glassfish</groupId>
-                        <artifactId>jakarta.el</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.logback</groupId>
@@ -944,12 +938,6 @@
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-bean-validation</artifactId>
                 <version>3.1.9</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.glassfish</groupId>
-                        <artifactId>jakarta.el</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>

--- a/worker-jobtracking-container/pom.xml
+++ b/worker-jobtracking-container/pom.xml
@@ -42,6 +42,15 @@
             <groupId>com.github.jobservice</groupId>
             <artifactId>worker-jobtracking</artifactId>
         </dependency>
+        <!--
+            Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
+            This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and a
+            version of DropWizard that includes it is released.
+        -->
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.github.jobservice</groupId>
             <artifactId>job-service-db</artifactId>

--- a/worker-jobtracking-container/pom.xml
+++ b/worker-jobtracking-container/pom.xml
@@ -42,12 +42,12 @@
             <groupId>com.github.jobservice</groupId>
             <artifactId>worker-jobtracking</artifactId>
         </dependency>
-        <!--
-            Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
-            This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and a
-            version of DropWizard that includes it is released.
-        -->
         <dependency>
+            <!--
+                Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
+                This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and
+                a version of DropWizard that includes it is released.
+            -->
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
         </dependency>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=982029