### PR TITLE
D992194: Fix to make getjobs function partition aware when jobid is the same

### DIFF
--- a/job-service-db/src/main/resources/db/migration/functions/public/R__getJobs.sql
+++ b/job-service-db/src/main/resources/db/migration/functions/public/R__getJobs.sql
@@ -189,7 +189,7 @@ BEGIN
                                     status = j.status,
                                     percentage_complete = j.percentage_complete
             FROM job j
-            WHERE nt.job_id = j.job_id;
+            WHERE nt.job_id = j.job_id AND j.partition_id = in_partition_id;
         END LOOP;
 
     END IF;

--- a/release-notes-9.1.0.md
+++ b/release-notes-9.1.0.md
@@ -4,5 +4,10 @@
 ${version-number}
 
 #### New Features
+- None
+
+#### Bug Fixes
+- D992194: Fix to make getJobs function partition aware when jobId is the same.
 
 #### Known Issues
+- None


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=992194