### PR TITLE
D998053: Fixed the size of the parent task id variable

### DIFF
--- a/job-service-db/src/main/resources/db/migration/functions/internal/R__internal__isTaskCompleted.sql
+++ b/job-service-db/src/main/resources/db/migration/functions/internal/R__internal__isTaskCompleted.sql
@@ -28,7 +28,7 @@ RETURNS BOOLEAN
 LANGUAGE plpgsql STABLE
 AS $$
 DECLARE
-    v_parent_task_id VARCHAR(58);
+    v_parent_task_id VARCHAR(70);
     v_parent_task_table VARCHAR(63);
     v_is_task_completed BOOLEAN;
 

--- a/release-notes-9.1.0.md
+++ b/release-notes-9.1.0.md
@@ -6,4 +6,7 @@ ${version-number}
 #### New Features
 - US921241: Job Service GET calls have been extended to include Status parameter
 
+#### Bug Fixes
+- D998053: Fixed `isTaskCompleted()` issue that impacts very large jobs
+
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=998053

This was meant to have been updated in #242.  Apparently it was missed.