### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-deploy</artifactId>
+    <name>job-service-deploy</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-docs</artifactId>
+    <name>job-service-docs</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/job-service-acceptance-tests/pom.xml
+++ b/job-service-acceptance-tests/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-acceptance-tests</artifactId>
+    <name>job-service-acceptance-tests</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/job-service-caller/pom.xml
+++ b/job-service-caller/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-caller</artifactId>
+    <name>job-service-caller</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/job-service-container-tests/pom.xml
+++ b/job-service-container-tests/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-container-tests</artifactId>
+    <name>job-service-container-tests</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/job-service-container/pom.xml
+++ b/job-service-container/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-container</artifactId>
+    <name>job-service-container</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/job-service-contract/pom.xml
+++ b/job-service-contract/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-contract</artifactId>
+    <name>job-service-contract</name>
 
     <parent>
         <groupId>com.github.jobservice</groupId>

--- a/job-service-db/pom.xml
+++ b/job-service-db/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-db</artifactId>
+    <name>job-service-db</name>
 
     <parent>
         <groupId>com.github.jobservice</groupId>

--- a/job-service-dropwizard/pom.xml
+++ b/job-service-dropwizard/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>job-service-dropwizard</artifactId>
+    <name>job-service-dropwizard</name>
 
     <properties>
         <debug.argument>-showversion</debug.argument>

--- a/job-service-internal-client/pom.xml
+++ b/job-service-internal-client/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>job-service-internal-client</artifactId>
+    <name>job-service-internal-client</name>
 
     <dependencies>
         <dependency>

--- a/job-service-postgres-container/pom.xml
+++ b/job-service-postgres-container/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-postgres-container</artifactId>
+    <name>job-service-postgres-container</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/job-service-scheduled-executor-container/pom.xml
+++ b/job-service-scheduled-executor-container/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>job-service-scheduled-executor-container</artifactId>
+    <name>job-service-scheduled-executor-container</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/job-service-testing-worker-shared/pom.xml
+++ b/job-service-testing-worker-shared/pom.xml
@@ -28,6 +28,7 @@
 
     <groupId>com.github.jobservice</groupId>
     <artifactId>job-service-testing-worker-shared</artifactId>
+    <name>job-service-testing-worker-shared</name>
 
     <dependencies>
         <dependency>

--- a/job-service-unit-tests/pom.xml
+++ b/job-service-unit-tests/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>job-service-unit-tests</artifactId>
+    <name>job-service-unit-tests</name>
 
     <properties>
         <maven.install.skip>true</maven.install.skip>

--- a/worker-jobtracking-container-tests/pom.xml
+++ b/worker-jobtracking-container-tests/pom.xml
@@ -29,6 +29,7 @@
 
     <groupId>com.github.jobservice.workers.jobtracking</groupId>
     <artifactId>worker-jobtracking-container-tests</artifactId>
+    <name>worker-jobtracking-container-tests</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/worker-jobtracking-container/pom.xml
+++ b/worker-jobtracking-container/pom.xml
@@ -29,6 +29,7 @@
 
     <groupId>com.github.jobservice.workers.jobtracking</groupId>
     <artifactId>worker-jobtracking-container</artifactId>
+    <name>worker-jobtracking-container</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/worker-jobtracking-shared/pom.xml
+++ b/worker-jobtracking-shared/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice.workers.jobtracking</groupId>
     <artifactId>worker-jobtracking-shared</artifactId>
+    <name>worker-jobtracking-shared</name>
 
     <parent>
         <groupId>com.github.jobservice</groupId>

--- a/worker-jobtracking/pom.xml
+++ b/worker-jobtracking/pom.xml
@@ -22,6 +22,7 @@
 
     <groupId>com.github.jobservice.workers.jobtracking</groupId>
     <artifactId>worker-jobtracking</artifactId>
+    <name>worker-jobtracking</name>
 
     <parent>
         <groupId>com.github.jobservice</groupId>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210