### PR TITLE
D1041027: Improve error handling in the Job Service Scheduled Executor

### DIFF
--- a/job-service-db/src/main/resources/db/migration/functions/public/R__reportFailureAndDeleteDependentJob.sql
+++ b/job-service-db/src/main/resources/db/migration/functions/public/R__reportFailureAndDeleteDependentJob.sql
@@ -1,0 +1,37 @@
+--
+-- Copyright 2016-2022 Micro Focus or one of its affiliates.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+/*
+ *  Name: report_failure_and_delete_dependent_job
+ *
+ *  Description:
+ *  Update the specified task and subsequent parent tasks/job with the failure details,
+ *  then delete dependent jobs if the failure reporting succeeds. Both operations are
+ *  executed within a single transaction.
+ */
+CREATE OR REPLACE FUNCTION report_failure_and_delete_dependent_job(
+    in_partition_id VARCHAR(40),
+    in_job_id VARCHAR(70),
+    in_failure_details TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM report_failure(in_partition_id, in_job_id, in_failure_details);
+    PERFORM delete_dependent_job(in_partition_id, in_job_id);
+END
+$$;

--- a/job-service-scheduled-executor/pom.xml
+++ b/job-service-scheduled-executor/pom.xml
@@ -30,6 +30,16 @@
     </parent>
 
     <dependencies>
+        <!-- JSON mapping -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.github.cafapi.logging</groupId>
             <artifactId>caf-logging-logback</artifactId>

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/DatabasePoller.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/DatabasePoller.java
@@ -90,75 +90,44 @@ public class DatabasePoller
 
         try (final QueueServices queueServices = QueueServicesFactory.create(taskPipe, partitionId, codec)) {
 
-//            final int WAIT_TIME_MILLIS = 120_000;
-//            final int INTERVAL_MILLIS = 10_000;
-//
-//            try {
-//                for (int remaining = WAIT_TIME_MILLIS; remaining > 0; remaining -= INTERVAL_MILLIS) {
-//                    LOG.info("Waiting... {} seconds remaining before publishing message to RabbitMQ.", remaining / 1000);
-//                    Thread.sleep(INTERVAL_MILLIS);
-//                }
-//            } catch (final InterruptedException e) {
-//                Thread.currentThread().interrupt();
-//                LOG.warn("Thread was interrupted during countdown wait.", e);
-//            }
-
             queueServices.sendMessage(partitionId, jobId, workerAction);
-        } catch (final Exception exception) {
-            final ExceptionType exceptionType = ExceptionAnalyzer.analyzeException(exception);
 
-            if (exceptionType == ExceptionType.NON_TRANSIENT) {
-                final String message = MessageFormat.format(
-                        "Non-transient RabbitMQ failure occurred while publishing message. {0}: {1}",
-                        context, exception.getMessage());
-
-                LOG.error(message, exception);
-
-                final QueueFailure failure = createFailureRecord(jobId, message);
-
-                final String failureJson;
-                try {
-                    failureJson = MAPPER.writeValueAsString(failure);
-                } catch (final JsonProcessingException jsonProcessingException) {
-                    LOG.error("Unable to serialize failure record to JSON. Job cannot be marked as failed " +
-                                    "and will remain in retry table and be retried. {}: {}", context,
-                            jsonProcessingException.getMessage(),
-                            jsonProcessingException);
-                    return;
-                }
-
-                try {
-                    reportFailure(partitionId, jobId, failureJson);
-                } catch (final ScheduledExecutorException reportFailureException) {
-                    LOG.error("Failed to mark job as failed. Job will remain in retry table " +
-                                    "and be retried. {}: {}", context, reportFailureException.getMessage(),
-                            reportFailureException);
-                    return;
-                }
-
-                try {
-                    deleteDependentJob(partitionId, jobId);
-                    return;
-                } catch (final ScheduledExecutorException deleteDependentJobException) {
-                    LOG.error("Successfully marked job as failed but unable to remove from retry table. " +
-                                    "Job will remain in retry table and be retried. {}: {}",
-                            context, deleteDependentJobException.getMessage(), deleteDependentJobException);
-                    return;
-                }
-            } else {
-                LOG.warn("Transient RabbitMQ failure occurred while publishing message. " +
-                        "Job will be retried. {}: {}", context, exception.getMessage(), exception);
-                return;
+            try {
+                deleteDependentJob(partitionId, jobId);
+            } catch (final ScheduledExecutorException | RuntimeException e) {
+                LOG.error("Message successfully published but failed to remove job from retry table. " +
+                                "Job will be retried. {}: {}",
+                        context, e.getMessage(), e);
             }
-        }
+        } catch (final Exception sendMessageException) {
+            final ExceptionType exceptionType = ExceptionAnalyzer.analyzeException(sendMessageException);
 
-        // If we reach here, the message was sent to RabbitMQ successfully, so delete the job from job_task_data.
-        try {
-            deleteDependentJob(partitionId, jobId);
-        } catch (final ScheduledExecutorException deleteDependentJobException) {
-            LOG.error("Message successfully published but failed to remove job from retry table. " +
-                            "Job will remain in retry table and be retried. {}: {}",
-                    context, deleteDependentJobException.getMessage(), deleteDependentJobException);
+            switch (exceptionType) {
+                case TRANSIENT:
+                    LOG.warn("Transient RabbitMQ failure occurred while publishing message. " +
+                            "Job will be retried. {}: {}",
+                            context, sendMessageException.getMessage(), sendMessageException);
+                    break;
+
+                case PERMANENT:
+                    final String reason = MessageFormat.format(
+                            "Permanent RabbitMQ failure occurred while publishing message. {0}: {1}",
+                            context, sendMessageException.getMessage());
+
+                    LOG.error(reason, sendMessageException);
+
+                    try {
+                        reportFailureAndDeleteDependentJob(partitionId, jobId, reason);
+                    } catch (final ScheduledExecutorException | JsonProcessingException | SQLException reportFailureException) {
+                        LOG.error("Failed to mark job as failed. Job will remain in retry table " +
+                                "and be retried. {}: {}",
+                                context, reportFailureException.getMessage(), reportFailureException);
+                    }
+                    break;
+
+                default:
+                    throw new RuntimeException("Unexpected exception type: " + exceptionType, sendMessageException);
+            }
         }
     }
 
@@ -220,35 +189,30 @@ public class DatabasePoller
         }
     }
 
-    private static QueueFailure createFailureRecord(final String jobId, final String reason)
+    private static void reportFailureAndDeleteDependentJob(
+            final String partitionId,
+            final String jobId,
+            final String reason)
+            throws JsonProcessingException, ScheduledExecutorException, SQLException
     {
         final QueueFailure failure = new QueueFailure();
         failure.setFailureId(FAILURE_ID);
         failure.setFailureTime(new Date());
         failure.failureSource(MessageFormat.format("Job Service Scheduled Executor for job id {0}", jobId));
         failure.failureMessage(reason);
-        return failure;
-    }
 
-    private static void reportFailure(final String partitionId, final String jobId, final String failureDetails)
-            throws ScheduledExecutorException
-    {
+        final String failureJson = MAPPER.writeValueAsString(failure);
+
         try (final Connection conn = DBConnection.get();
-             final CallableStatement stmt = conn.prepareCall("{call report_failure(?,?,?)}")) {
+             final CallableStatement stmt = conn.prepareCall("{call report_failure_and_delete_dependent_job(?,?,?)}")) {
             stmt.setString(1, partitionId);
             stmt.setString(2, jobId);
-            stmt.setString(3, failureDetails);
+            stmt.setString(3, failureJson);
 
-            LOG.info("Calling report_failure() database function with partitionId={}, jobId={}, failureDetails={} ...",
-                    partitionId, jobId, failureDetails);
+            LOG.info("Calling report_failure_and_delete_dependent_job() database function with " +
+                            "partitionId={}, jobId={}, failureDetails={} ...",
+                    partitionId, jobId, failureJson);
             stmt.execute();
-        } catch (final SQLException e) {
-            final String errorMessage = MessageFormat.format(
-                    "Failed in call to report_failure() database function with "
-                            + "partitionId={0}, jobId={1}, failureDetails={2}. {3}",
-                    partitionId, jobId, failureDetails, e.getMessage());
-            LOG.error(errorMessage);
-            throw new ScheduledExecutorException(errorMessage);
         }
     }
 }

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/DatabasePoller.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/DatabasePoller.java
@@ -48,7 +48,7 @@ public class DatabasePoller
     public static void pollDatabaseForJobsToRun() {
         try {
             //  Poll database for prerequisite jobs that are now available to be run.
-            LOG.info("Polling Job Service database for jobs to run ...");
+            LOG.debug("Polling Job Service database for jobs to run ...");
             final List<JobTaskData> jobsToRun = getDependentJobsToRun();
 
             //  Determine if there are any jobs to run.

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/DatabasePoller.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/DatabasePoller.java
@@ -15,6 +15,8 @@
  */
 package com.github.jobservice.scheduledexecutor;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.cafapi.common.api.Codec;
 import com.github.cafapi.common.util.moduleloader.ModuleLoader;
 import com.github.cafapi.common.util.moduleloader.ModuleLoaderException;
@@ -26,8 +28,11 @@ import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.text.DateFormat;
 import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -36,11 +41,14 @@ import java.util.List;
 public class DatabasePoller
 {
     private static final Logger LOG = LoggerFactory.getLogger(DatabasePoller.class);
+    private static final String FAILURE_ID = "ADD_TO_QUEUE_FAILURE";
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    private static final ObjectMapper MAPPER = new ObjectMapper().setDateFormat(DATE_FORMAT);
 
     public static void pollDatabaseForJobsToRun() {
         try {
             //  Poll database for prerequisite jobs that are now available to be run.
-            LOG.debug("Polling Job Service database for jobs to run ...");
+            LOG.info("Polling Job Service database for jobs to run ...");
             final List<JobTaskData> jobsToRun = getDependentJobsToRun();
 
             //  Determine if there are any jobs to run.
@@ -72,18 +80,88 @@ public class DatabasePoller
         }
     }
 
-    private static void sendMessageToQueueMessaging(final Codec codec, final JobTaskData jtd, final WorkerAction workerAction)
-    {
-        try (final QueueServices queueServices= QueueServicesFactory.create(jtd.getTaskPipe(), jtd.getPartitionId(), codec)){
-            queueServices.sendMessage(jtd.getPartitionId(), jtd.getJobId(), workerAction);
-            deleteDependentJob(jtd.getPartitionId(), jtd.getJobId());
-        } catch(final Exception ex) {
-            LOG.warn(MessageFormat.format(
-                    "Exception thrown during processing of job with partition ID {0}, job ID {1} and task data {2}",
-                    jtd.getPartitionId(), jtd.getJobId(), workerAction), ex);
+    private static void sendMessageToQueueMessaging(final Codec codec, final JobTaskData jtd,
+                                                    final WorkerAction workerAction) {
+        final String partitionId = jtd.getPartitionId();
+        final String jobId = jtd.getJobId();
+        final String taskPipe = jtd.getTaskPipe();
+        final String context = MessageFormat.format("[partitionId={0}, jobId={1}, taskPipe={2}]",
+                partitionId, jobId, taskPipe);
+
+        try (final QueueServices queueServices = QueueServicesFactory.create(taskPipe, partitionId, codec)) {
+
+//            final int WAIT_TIME_MILLIS = 120_000;
+//            final int INTERVAL_MILLIS = 10_000;
+//
+//            try {
+//                for (int remaining = WAIT_TIME_MILLIS; remaining > 0; remaining -= INTERVAL_MILLIS) {
+//                    LOG.info("Waiting... {} seconds remaining before publishing message to RabbitMQ.", remaining / 1000);
+//                    Thread.sleep(INTERVAL_MILLIS);
+//                }
+//            } catch (final InterruptedException e) {
+//                Thread.currentThread().interrupt();
+//                LOG.warn("Thread was interrupted during countdown wait.", e);
+//            }
+
+            queueServices.sendMessage(partitionId, jobId, workerAction);
+        } catch (final Exception exception) {
+            final ExceptionType exceptionType = ExceptionAnalyzer.analyzeException(exception);
+
+            if (exceptionType == ExceptionType.NON_TRANSIENT) {
+                final String message = MessageFormat.format(
+                        "Non-transient RabbitMQ failure occurred while publishing message. {0}: {1}",
+                        context, exception.getMessage());
+
+                LOG.error(message, exception);
+
+                final QueueFailure failure = createFailureRecord(jobId, message);
+
+                final String failureJson;
+                try {
+                    failureJson = MAPPER.writeValueAsString(failure);
+                } catch (final JsonProcessingException jsonProcessingException) {
+                    LOG.error("Unable to serialize failure record to JSON. Job cannot be marked as failed " +
+                                    "and will remain in retry table and be retried. {}: {}", context,
+                            jsonProcessingException.getMessage(),
+                            jsonProcessingException);
+                    return;
+                }
+
+                try {
+                    reportFailure(partitionId, jobId, failureJson);
+                } catch (final ScheduledExecutorException reportFailureException) {
+                    LOG.error("Failed to mark job as failed. Job will remain in retry table " +
+                                    "and be retried. {}: {}", context, reportFailureException.getMessage(),
+                            reportFailureException);
+                    return;
+                }
+
+                try {
+                    deleteDependentJob(partitionId, jobId);
+                    return;
+                } catch (final ScheduledExecutorException deleteDependentJobException) {
+                    LOG.error("Successfully marked job as failed but unable to remove from retry table. " +
+                                    "Job will remain in retry table and be retried. {}: {}",
+                            context, deleteDependentJobException.getMessage(), deleteDependentJobException);
+                    return;
+                }
+            } else {
+                LOG.warn("Transient RabbitMQ failure occurred while publishing message. " +
+                        "Job will be retried. {}: {}", context, exception.getMessage(), exception);
+                return;
+            }
+        }
+
+        // If we reach here, the message was sent to RabbitMQ successfully, so delete the job from job_task_data.
+        try {
+            deleteDependentJob(partitionId, jobId);
+        } catch (final ScheduledExecutorException deleteDependentJobException) {
+            LOG.error("Message successfully published but failed to remove job from retry table. " +
+                            "Job will remain in retry table and be retried. {}: {}",
+                    context, deleteDependentJobException.getMessage(), deleteDependentJobException);
         }
     }
-    
+
     /**
      * Deletes the supplied job from the job_task_data database table.
      */
@@ -142,4 +220,35 @@ public class DatabasePoller
         }
     }
 
+    private static QueueFailure createFailureRecord(final String jobId, final String reason)
+    {
+        final QueueFailure failure = new QueueFailure();
+        failure.setFailureId(FAILURE_ID);
+        failure.setFailureTime(new Date());
+        failure.failureSource(MessageFormat.format("Job Service Scheduled Executor for job id {0}", jobId));
+        failure.failureMessage(reason);
+        return failure;
+    }
+
+    private static void reportFailure(final String partitionId, final String jobId, final String failureDetails)
+            throws ScheduledExecutorException
+    {
+        try (final Connection conn = DBConnection.get();
+             final CallableStatement stmt = conn.prepareCall("{call report_failure(?,?,?)}")) {
+            stmt.setString(1, partitionId);
+            stmt.setString(2, jobId);
+            stmt.setString(3, failureDetails);
+
+            LOG.info("Calling report_failure() database function with partitionId={}, jobId={}, failureDetails={} ...",
+                    partitionId, jobId, failureDetails);
+            stmt.execute();
+        } catch (final SQLException e) {
+            final String errorMessage = MessageFormat.format(
+                    "Failed in call to report_failure() database function with "
+                            + "partitionId={0}, jobId={1}, failureDetails={2}. {3}",
+                    partitionId, jobId, failureDetails, e.getMessage());
+            LOG.error(errorMessage);
+            throw new ScheduledExecutorException(errorMessage);
+        }
+    }
 }

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ExceptionAnalyzer.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ExceptionAnalyzer.java
@@ -1,0 +1,133 @@
+package com.github.jobservice.scheduledexecutor;
+
+/*
+ * Copyright 2016-2025 Open Text.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AlreadyClosedException;
+import com.rabbitmq.client.MissedHeartbeatException;
+import com.rabbitmq.client.PossibleAuthenticationFailureException;
+import com.rabbitmq.client.ShutdownSignalException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+final class ExceptionAnalyzer
+{
+    private static final Logger LOG = LoggerFactory.getLogger(ExceptionAnalyzer.class);
+
+    public static ExceptionType analyzeException(final Exception exception)
+    {
+        if (exception instanceof IllegalArgumentException ||
+                exception instanceof SecurityException ||
+                exception instanceof ClassNotFoundException ||
+                exception instanceof NoSuchMethodException ||
+                exception instanceof InstantiationException ||
+                exception instanceof PossibleAuthenticationFailureException) {
+            // Configuration, code-related errors are non-transient.
+            return ExceptionType.NON_TRANSIENT;
+        }
+
+        // Connection/channel state issues are considered transient in our case since when we retry a
+        // job/message we always create a new connection and channel for it
+        if (exception instanceof AlreadyClosedException ||
+                exception instanceof MissedHeartbeatException) {
+            return ExceptionType.TRANSIENT;
+        }
+
+        // Check for network-related exceptions (typically transient)
+        if (exception instanceof IOException || exception instanceof TimeoutException) {
+            // Network issues are typically transient.
+            return ExceptionType.TRANSIENT;
+        }
+
+        // Default to non-transient for unknown exceptions to prevent infinite retry loops
+        LOG.error("Unknown exception type encountered: {}. Assuming NON-TRANSIENT to prevent retry loop.",
+                exception.getClass().getName());
+        return ExceptionType.NON_TRANSIENT;
+    }
+
+
+    private static ExceptionType analyzeShutdownException(
+            final ShutdownSignalException shutdownException)
+    {
+
+        if (shutdownException.isInitiatedByApplication()) {
+            return ExceptionType.TRANSIENT;
+        }
+
+        final Object reason = shutdownException.getReason();
+        final int replyCode = extractReplyCode(reason);
+
+        if (replyCode == -1) {
+            boolean isIoException = shutdownException.getCause() instanceof IOException;
+            return isIoException ? ExceptionType.TRANSIENT :
+                    ExceptionType.NON_TRANSIENT;
+        }
+
+        return isReplyCodeTransient(replyCode) ? ExceptionType.TRANSIENT :
+                ExceptionType.NON_TRANSIENT;
+    }
+
+    private static int extractReplyCode(final Object reason)
+    {
+        if (reason instanceof AMQP.Connection.Close closeConnection) {
+            return closeConnection.getReplyCode();
+        }
+        if (reason instanceof AMQP.Channel.Close closeChannel) {
+            return closeChannel.getReplyCode();
+        }
+        return -1;
+    }
+
+    private static boolean isReplyCodeTransient(final int replyCode)
+    {
+        return switch (replyCode) {
+            // Transient conditions that may resolve with a retry
+            case AMQP.REPLY_SUCCESS,            // 200 - graceful shutdown, may come back online
+                 AMQP.NO_CONSUMERS,             // 313 - consumers may reconnect
+                 AMQP.CONNECTION_FORCED,        // 320 - administrative action, could be temporary
+                 AMQP.RESOURCE_LOCKED,          // 405 - exclusive access conflict, may resolve
+                 AMQP.COMMAND_INVALID,          // 503 - broker maintenance, temporary
+                 AMQP.RESOURCE_ERROR,           // 506 - memory/disk issues, may be temporary
+                 AMQP.INTERNAL_ERROR            // 541 - often recoverable
+                    -> true;
+
+            // Non-transient conditions that will not resolve with a retry
+            case AMQP.CONTENT_TOO_LARGE,        // 311 - message size exceeds broker limits
+                 AMQP.NO_ROUTE,                 // 312 - no matching route for message
+                 AMQP.ACCESS_REFUSED,           // 403 - authentication/authorization failure
+                 AMQP.NOT_FOUND,                // 404 - requested resource does not exist
+                 AMQP.PRECONDITION_FAILED,      // 406 - method preconditions not met
+                 AMQP.INVALID_PATH,             // 402 - malformed path or routing key
+                 AMQP.FRAME_ERROR,              // 501 - protocol frame format error
+                 AMQP.SYNTAX_ERROR,             // 502 - command syntax incorrect
+                 AMQP.CHANNEL_ERROR,            // 504 - channel-specific protocol error
+                 AMQP.UNEXPECTED_FRAME,         // 505 - frame received in wrong state
+                 AMQP.NOT_ALLOWED,              // 530 - operation not permitted by policy
+                 AMQP.NOT_IMPLEMENTED           // 540 - requested feature not supported
+                    -> false;
+
+            // Default to non-transient for unknown codes to prevent infinite retries
+            default -> {
+                LOG.warn("Unknown AMQP reply code: {}. Assuming NON-TRANSIENT to prevent retry loop.", replyCode);
+                yield false;
+            }
+        };
+    }
+}

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ExceptionAnalyzer.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ExceptionAnalyzer.java
@@ -33,40 +33,41 @@ final class ExceptionAnalyzer
 
     public static ExceptionType analyzeException(final Exception exception)
     {
+        // Configuration, code-related errors are permanent
         if (exception instanceof IllegalArgumentException ||
                 exception instanceof SecurityException ||
                 exception instanceof ClassNotFoundException ||
                 exception instanceof NoSuchMethodException ||
                 exception instanceof InstantiationException ||
                 exception instanceof PossibleAuthenticationFailureException) {
-            // Configuration, code-related errors are non-transient.
-            return ExceptionType.NON_TRANSIENT;
+
+            return ExceptionType.PERMANENT;
         }
 
-        // Connection/channel state issues are considered transient in our case since when we retry a
-        // job/message we always create a new connection and channel for it
-        if (exception instanceof AlreadyClosedException ||
-                exception instanceof MissedHeartbeatException) {
+        // Connection/channel state issues are transient as we create new connections/channels when retrying
+        if (exception instanceof AlreadyClosedException || exception instanceof MissedHeartbeatException) {
             return ExceptionType.TRANSIENT;
+        }
+
+        // Handle ShutdownSignalException with AMQP reply code analysis
+        if (exception instanceof ShutdownSignalException shutdownException) {
+            return analyzeShutdownException(shutdownException);
         }
 
         // Check for network-related exceptions (typically transient)
         if (exception instanceof IOException || exception instanceof TimeoutException) {
-            // Network issues are typically transient.
             return ExceptionType.TRANSIENT;
         }
 
-        // Default to non-transient for unknown exceptions to prevent infinite retry loops
-        LOG.error("Unknown exception type encountered: {}. Assuming NON-TRANSIENT to prevent retry loop.",
+        // Default to permanent for unknown exceptions to prevent infinite retry loops
+        LOG.error("Unknown exception type encountered: {}. Assuming PERMANENT to prevent retry loop.",
                 exception.getClass().getName());
-        return ExceptionType.NON_TRANSIENT;
+        return ExceptionType.PERMANENT;
     }
-
 
     private static ExceptionType analyzeShutdownException(
             final ShutdownSignalException shutdownException)
     {
-
         if (shutdownException.isInitiatedByApplication()) {
             return ExceptionType.TRANSIENT;
         }
@@ -76,12 +77,10 @@ final class ExceptionAnalyzer
 
         if (replyCode == -1) {
             boolean isIoException = shutdownException.getCause() instanceof IOException;
-            return isIoException ? ExceptionType.TRANSIENT :
-                    ExceptionType.NON_TRANSIENT;
+            return isIoException ? ExceptionType.TRANSIENT : ExceptionType.PERMANENT;
         }
 
-        return isReplyCodeTransient(replyCode) ? ExceptionType.TRANSIENT :
-                ExceptionType.NON_TRANSIENT;
+        return isReplyCodeTransient(replyCode) ? ExceptionType.TRANSIENT : ExceptionType.PERMANENT;
     }
 
     private static int extractReplyCode(final Object reason)
@@ -108,7 +107,7 @@ final class ExceptionAnalyzer
                  AMQP.INTERNAL_ERROR            // 541 - often recoverable
                     -> true;
 
-            // Non-transient conditions that will not resolve with a retry
+            // Permanent conditions that will not resolve with a retry
             case AMQP.CONTENT_TOO_LARGE,        // 311 - message size exceeds broker limits
                  AMQP.NO_ROUTE,                 // 312 - no matching route for message
                  AMQP.ACCESS_REFUSED,           // 403 - authentication/authorization failure
@@ -123,9 +122,9 @@ final class ExceptionAnalyzer
                  AMQP.NOT_IMPLEMENTED           // 540 - requested feature not supported
                     -> false;
 
-            // Default to non-transient for unknown codes to prevent infinite retries
+            // Default to permanent for unknown codes to prevent infinite retries
             default -> {
-                LOG.warn("Unknown AMQP reply code: {}. Assuming NON-TRANSIENT to prevent retry loop.", replyCode);
+                LOG.warn("Unknown AMQP reply code: {}. Assuming PERMANENT to prevent retry loop.", replyCode);
                 yield false;
             }
         };

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ExceptionType.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ExceptionType.java
@@ -18,5 +18,5 @@ package com.github.jobservice.scheduledexecutor;
 enum ExceptionType
 {
     TRANSIENT,
-    NON_TRANSIENT
+    PERMANENT
 }

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ExceptionType.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ExceptionType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016-2025 Open Text.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jobservice.scheduledexecutor;
+
+enum ExceptionType
+{
+    TRANSIENT,
+    NON_TRANSIENT
+}

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/QueueServices.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/QueueServices.java
@@ -45,6 +45,9 @@ public final class QueueServices implements AutoCloseable
 {
     private static final Logger LOG = LoggerFactory.getLogger(QueueServices.class);
 
+    private static final int RABBIT_MQ_PUBLISH_TIMEOUT_MILLIS =
+            ScheduledExecutorConfig.getRabbitMQPublishTimeoutSeconds() * 1000;
+
     private final Connection connection;
     private final Channel publisherChannel;
     private final String targetQueue;               // Queue that should be set in the 'to' field of the task message
@@ -72,7 +75,8 @@ public final class QueueServices implements AutoCloseable
      */
     public void sendMessage(
         final String partitionId, final String jobId, final WorkerAction workerAction
-    ) throws IOException, URISyntaxException {
+    ) throws IOException, URISyntaxException, InterruptedException, TimeoutException
+    {
         //  Generate a random task id.
         LOG.debug("Generating task id ...");
         final String taskId = UUID.randomUUID().toString();
@@ -110,6 +114,7 @@ public final class QueueServices implements AutoCloseable
         }
 
         publisherChannel.basicPublish("", targetQueue, true, MessageProperties.PERSISTENT_TEXT_PLAIN, taskMessageBytes);
+        publisherChannel.waitForConfirmsOrDie(RABBIT_MQ_PUBLISH_TIMEOUT_MILLIS);
     }
 
     private TaskMessage getTaskMessage(

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/QueueServicesFactory.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/QueueServicesFactory.java
@@ -76,6 +76,9 @@ public final class QueueServicesFactory
         LOG.debug("Creating channel ...");
         final Channel publishChannel = connection.createChannel();
 
+        // Enable publishing acknowledgements
+        publishChannel.confirmSelect();
+
         //  Declare worker queue.
         LOG.debug("Declaring worker queue {}...", targetQueue);
 

--- a/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ScheduledExecutorConfig.java
+++ b/job-service-scheduled-executor/src/main/java/com/github/jobservice/scheduledexecutor/ScheduledExecutorConfig.java
@@ -111,6 +111,14 @@ public class ScheduledExecutorConfig {
         }
     }
 
+    public static int getRabbitMQPublishTimeoutSeconds() {
+        final String rabbitmqPublishTimeoutSeconds = getPropertyOrEnvVar("CAF_RABBITMQ_PUBLISH_TIMEOUT_SECONDS");
+        if (null == rabbitmqPublishTimeoutSeconds || rabbitmqPublishTimeoutSeconds.isEmpty()) {
+            return 10;
+        }
+        return Integer.parseInt(rabbitmqPublishTimeoutSeconds);
+    }
+
     public static String getTrackingPipe() {
         return getPropertyOrEnvVar("CAF_TRACKING_PIPE");
     }

--- a/release-notes-10.1.0.md
+++ b/release-notes-10.1.0.md
@@ -4,5 +4,13 @@
 ${version-number}
 
 #### New Features
+- None
+
+#### Bug Fixes
+- D1041027: Improved error handling in the Job Service Scheduled Executor.  
+  - A transient error sending a message to RabbitMQ will result in the job being retried during the next execution cycle.
+  - A non-transient error sending a message to RabbitMQ will result in the job being marked as failed and the job
+    will NOT be retried during the next execution cycle.
 
 #### Known Issues
+- None

--- a/release-notes-10.1.0.md
+++ b/release-notes-10.1.0.md
@@ -9,7 +9,7 @@ ${version-number}
 #### Bug Fixes
 - D1041027: Improved error handling in the Job Service Scheduled Executor.  
   - A transient error sending a message to RabbitMQ will result in the job being retried during the next execution cycle.
-  - A non-transient error sending a message to RabbitMQ will result in the job being marked as failed and the job
+  - A permanent error sending a message to RabbitMQ will result in the job being marked as failed and the job
     will NOT be retried during the next execution cycle.
 
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1041027

  - A transient error sending a message to RabbitMQ (e.g. RabbitMQ being unavailable) will result in the job being retried during the next execution cycle.
  
  - A permanent error sending a message to RabbitMQ (e.g. a message above RabbitMQ's max_message_size) will result in the job being marked as failed and the job will NOT be retried during the next execution cycle.