### PR TITLE
US1107289: Update `caf-ssl` version to use PQC TLS support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
             <dependency>
                 <groupId>com.github.cafapi.ssl</groupId>
                 <artifactId>caf-ssl-dropwizard</artifactId>
-                <version>1.2.0-62</version>
+                <version>1.3.0-462</version>
             </dependency>
             <dependency>
                 <groupId>com.github.cafapi.util.dropwizard</groupId>

--- a/release-notes-10.3.0.md
+++ b/release-notes-10.3.0.md
@@ -5,5 +5,6 @@ ${version-number}
 
 #### New Features
 - **US1138334**: Updated to run on Java 25.
+- **US1107289**: Add support for PQC TLS Hybrid exchange.
 
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1107289